### PR TITLE
feat: DatasetRegister, Section, OrderingMethod, ConceptReferenceType models

### DIFF
--- a/concept-model
+++ b/concept-model
@@ -1,0 +1,1 @@
+/Users/mulgogi/src/glossarist/concept-model

--- a/models/concepts/ConceptReferenceType.lutaml
+++ b/models/concepts/ConceptReferenceType.lutaml
@@ -1,0 +1,34 @@
+enum ConceptReferenceType {
+  definition {
+    The type of reference from a concept to another concept or group,
+    distinguishing thematic from structural classification.
+  }
+
+  domain {
+    definition {
+      A thematic or subject-area classification. The referenced concept
+      represents a terminological domain (e.g. "mathematics", "physics").
+    }
+  }
+
+  section {
+    definition {
+      A structural section membership within the dataset's organizational
+      hierarchy. The referenced concept represents a section defined in
+      the dataset's register.yaml (e.g. "Section 3: General concepts").
+    }
+  }
+
+  local {
+    definition {
+      An internal reference within the same glossary, without an external
+      source URN.
+    }
+  }
+
+  designation {
+    definition {
+      A reference to a specific designation within the same concept entry.
+    }
+  }
+}

--- a/models/concepts/DatasetRegister.lutaml
+++ b/models/concepts/DatasetRegister.lutaml
@@ -1,0 +1,144 @@
+class DatasetRegister {
+  definition {
+    Self-describing dataset metadata. Each dataset directory contains a
+    register.yaml that carries identity, structure, and relationship
+    metadata. Concepts are discovered from the concepts/ directory,
+    not enumerated in the register.
+  }
+
+  // ── Identity ────────────────────────────────────────────────────
+  +schema_type: String [1] {
+    definition {
+      Always "glossarist". Identifies this file as a Glossarist register.
+    }
+  }
+
+  +schema_version: String [1] {
+    definition {
+      Schema version. Currently "3".
+    }
+  }
+
+  +id: String [1] {
+    definition {
+      Dataset identifier, unique within the deployment.
+      Examples: "viml-2022", "vim-2012", "iev".
+    }
+  }
+
+  +ref: String [0..1] {
+    definition {
+      Publication reference string.
+      Examples: "OIML V 1:2022", "IEC 60050:2011".
+    }
+  }
+
+  +year: Integer [0..1] {
+    definition {
+      Publication year.
+    }
+  }
+
+  // ── URN and resolution ─────────────────────────────────────────
+  +urn: String [1] {
+    definition {
+      Primary URN for the dataset. Used for cross-dataset resolution.
+      Example: "urn:oiml:pub:v:1:2022".
+    }
+  }
+
+  +urnAliases: String [0..*] {
+    definition {
+      Additional URN patterns for resolution. Wildcard suffix (*) matches
+      any concept within the dataset.
+    }
+  }
+
+  +refAliases: String [0..*] {
+    definition {
+      Alternative publication references.
+    }
+  }
+
+  // ── Status ─────────────────────────────────────────────────────
+  +status: String [0..1] {
+    definition {
+      Dataset lifecycle status: "current", "superseded", "retired".
+    }
+  }
+
+  +supersedes: String [0..1] {
+    definition {
+      ID of the dataset edition that this one supersedes.
+      This is a dataset-level relationship, distinct from concept-level
+      supersedes in related[].
+    }
+  }
+
+  // ── Provenance ─────────────────────────────────────────────────
+  +owner: String [0..1] {
+    definition {
+      Organization that owns the dataset.
+      Examples: "OIML", "IEC", "ISO".
+    }
+  }
+
+  +sourceRepo: String [0..1] {
+    definition {
+      URL of the source repository.
+    }
+  }
+
+  +tags: String [0..*] {
+    definition {
+      Organizational tags for the dataset.
+    }
+  }
+
+  // ── Languages ──────────────────────────────────────────────────
+  +languages: String [1..*] {
+    definition {
+      ISO 639-2 language codes available in this dataset.
+    }
+  }
+
+  +languageOrder: String [0..*] {
+    definition {
+      Preferred display order for languages.
+    }
+  }
+
+  // ── Structure ──────────────────────────────────────────────────
+  +ordering: OrderingMethod [0..1] {
+    definition {
+      Default concept ordering method for the entire dataset.
+      Individual sections may override this.
+    }
+  }
+
+  +sections: Section [0..*] {
+    definition {
+      Hierarchical section tree. Sections provide structural organization
+      and are referenced by concepts via domains[] with ref_type "section".
+    }
+  }
+
+  // ── Per-dataset metadata ───────────────────────────────────────
+  +description: LocalizedStringMap [0..1] {
+    definition {
+      Localized dataset description, keyed by language code.
+    }
+  }
+
+  +about: LocalizedStringMap [0..1] {
+    definition {
+      Localized paths to about-page documents, keyed by language code.
+    }
+  }
+
+  +logo: String [0..1] {
+    definition {
+      Relative path to the dataset logo image.
+    }
+  }
+}

--- a/models/concepts/OrderingMethod.lutaml
+++ b/models/concepts/OrderingMethod.lutaml
@@ -1,0 +1,28 @@
+enum OrderingMethod {
+  definition {
+    The method used to order concepts within a dataset or section,
+    following ISO 10241-1 conventions.
+  }
+
+  systematic {
+    definition {
+      Tree hierarchy, top-down left-to-right. Broader concepts before
+      narrower. Uses dot-separated identifiers (e.g. 3.6, 3.6.1) and
+      explicit broader/narrower edges.
+    }
+  }
+
+  mixed {
+    definition {
+      Pedagogical sequence: fundamental concepts first, then specific.
+      No strict tree hierarchy.
+    }
+  }
+
+  alphabetical {
+    definition {
+      Sorted by preferred designation. Derived at render time from
+      localized concept data.
+    }
+  }
+}

--- a/models/concepts/Section.lutaml
+++ b/models/concepts/Section.lutaml
@@ -1,0 +1,36 @@
+class Section {
+  definition {
+    A structural division within a dataset, providing organizational
+    grouping for concepts. Sections can be hierarchical: a section
+    may contain child sections (e.g. Part > Section > Subsection).
+    Sections are defined in the dataset's register.yaml.
+  }
+
+  +id: String [1] {
+    definition {
+      Section identifier, used in concept references and URL routing.
+      Examples: "0", "1", "3", "103-01", "A".
+    }
+  }
+
+  +names: LocalizedStringMap [0..1] {
+    definition {
+      Localized section titles, keyed by ISO 639-2 language code.
+      Example: { eng: "Basic terms", fra: "Termes fondamentaux" }.
+    }
+  }
+
+  +ordering: OrderingMethod [0..1] {
+    definition {
+      Per-section ordering override. If absent, inherits from the
+      dataset's default ordering.
+    }
+  }
+
+  +children: Section [0..*] {
+    definition {
+      Child sections forming a hierarchical tree. For example,
+      area "103" contains sections "103-01", "103-02", etc.
+    }
+  }
+}

--- a/schemas/v3/register.yaml
+++ b/schemas/v3/register.yaml
@@ -1,0 +1,168 @@
+%YAML 1.1
+# yaml-language-server: $schema=http://json-schema.org/draft-07/schema
+---
+$id: "https://github.com/glossarist/concept-model/v3/register"
+title: YAML Schema for Dataset Register model (v3)
+description: |
+  Schema for register.yaml — the self-describing dataset metadata file.
+  Each dataset directory contains this file with identity, structure,
+  relationships, and organizational metadata.
+type: object
+required:
+  - schema_type
+  - schema_version
+  - id
+  - urn
+properties:
+  schema_type:
+    type: string
+    const: glossarist
+    description: Always "glossarist".
+
+  schema_version:
+    type: string
+    description: Schema version.
+    examples:
+      - "3"
+
+  id:
+    type: string
+    description: Dataset identifier, unique within deployment.
+    examples:
+      - viml-2022
+      - vim-2012
+      - iev
+
+  ref:
+    type: string
+    description: Publication reference string.
+    examples:
+      - "OIML V 1:2022"
+      - "IEC 60050:2011"
+
+  year:
+    type: integer
+    description: Publication year.
+    examples:
+      - 2022
+      - 2012
+
+  urn:
+    type: string
+    description: Primary URN for the dataset.
+    examples:
+      - "urn:oiml:pub:v:1:2022"
+      - "urn:iec:std:iec:60050"
+
+  urnAliases:
+    type: array
+    items:
+      type: string
+    description: Additional URN patterns for resolution.
+
+  refAliases:
+    type: array
+    items:
+      type: string
+    description: Alternative publication references.
+
+  status:
+    type: string
+    enum:
+      - current
+      - superseded
+      - retired
+    description: Dataset lifecycle status.
+
+  supersedes:
+    type: string
+    description: ID of the dataset edition that this one supersedes.
+
+  owner:
+    type: string
+    description: Owning organization.
+    examples:
+      - OIML
+      - IEC
+      - ISO
+
+  sourceRepo:
+    type: string
+    description: URL of the source repository.
+
+  tags:
+    type: array
+    items:
+      type: string
+    description: Organizational tags.
+
+  languages:
+    type: array
+    items:
+      type: string
+      minLength: 3
+      maxLength: 3
+    description: ISO 639-2 language codes available.
+
+  languageOrder:
+    type: array
+    items:
+      type: string
+    description: Preferred display order for languages.
+
+  ordering:
+    type: string
+    enum:
+      - systematic
+      - mixed
+      - alphabetical
+    description: Default concept ordering method.
+
+  sections:
+    type: array
+    items:
+      $ref: "#/$defs/section"
+    description: Hierarchical section tree.
+
+  description:
+    type: object
+    description: Localized dataset descriptions keyed by language code.
+    additionalProperties:
+      type: string
+
+  about:
+    type: object
+    description: Localized about-page paths keyed by language code.
+    additionalProperties:
+      type: string
+
+  logo:
+    type: string
+    description: Relative path to dataset logo.
+
+$defs:
+  section:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: Section identifier.
+      names:
+        type: object
+        description: Localized section titles keyed by language code.
+        additionalProperties:
+          type: string
+      ordering:
+        type: string
+        enum:
+          - systematic
+          - mixed
+          - alphabetical
+        description: Per-section ordering override.
+      children:
+        type: array
+        items:
+          $ref: "#/$defs/section"
+        description: Child sections.


### PR DESCRIPTION
Adds data model definitions for self-describing datasets with hierarchical sections.

## New models

- **DatasetRegister** (`DatasetRegister.lutaml`) — Self-describing dataset metadata: identity (id, ref, year), URN resolution, sections, ordering, languages, provenance, supersedes relationship. Replaces the need for external config files like editions.yml.

- **Section** (`Section.lutaml`) — Hierarchical organizational division with `id`, `names` (localized), `ordering` override, and recursive `children`. Enables part > section > subsection hierarchies.

- **OrderingMethod** (`OrderingMethod.lutaml`) — Enum: systematic (tree hierarchy, ISO 10241-1), mixed (pedagogical), alphabetical (derived at render time).

- **ConceptReferenceType** (`ConceptReferenceType.lutaml`) — Enum distinguishing domain (thematic) from section (structural) references.

## JSON Schema

- `schemas/v3/register.yaml` — Full YAML Schema for register.yaml validation, including recursive section definitions.

## Context

These models are implemented in:
- glossarist-js (Register, Section classes — released v0.3.1)
- concept-browser (hierarchical sidebar, section filtering, alphabetical view)
- glossarist-ruby (PR pending)
- iev gem (register.yaml generation with area>section hierarchy)
- oiml-vocab (8 register.yaml files, all concepts use ref_type: section)