### PR TITLE
feat: add DesignationRelationship, ConceptRef text, annotations, 52 relationship types

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,6 +12,7 @@ These models align with multiple ISO standards for terminology management:
 * **ISO 30042 / TBX** — Terminology markup framework (data exchange)
 * **ISO 12620** — Data category registry (term types, register, grammar)
 * **ISO 25964 / SKOS** — Thesaurus interoperability (hierarchical and mapping relationships)
+* **ISO 19135** — Geographic information — Procedures for item registration (register management, versioning)
 * **ISO 639** — Language codes
 * **ISO 15924** — Script codes
 * **ISO 24229** — Conversion system codes
@@ -70,24 +71,60 @@ All types inherit from Base: `designation`, `normative_status`, `geographical_ar
 `absent`, `pronunciation`, `sources`, `term_type`, `related`, `register`.
 
 
-== Relationship Types (32)
+== Relationship Types (52)
 
-Typed semantic links between concepts, spanning four standards:
+Typed semantic links between concepts, spanning five standards:
 
 | Category | Standard | Types |
 |----------|----------|-------|
-| Lifecycle | ISO 10241-1 | `deprecates`, `supersedes`, `superseded_by` |
-| Hierarchical | ISO 10241-1 / ISO 25964 | `broader`, `narrower` |
-| Generic hierarchy | ISO 25964 (BTG/NTG) | `broader_generic`, `narrower_generic` |
-| Partitive hierarchy | ISO 25964 (BTP/NTP) | `broader_partitive`, `narrower_partitive` |
-| Instantial hierarchy | ISO 25964 (BTI/NTI) | `broader_instantial`, `narrower_instantial` |
-| Equivalence | ISO 10241-1 / ISO 25964 / SKOS | `equivalent`, `exact_match` |
+| Lifecycle | ISO 10241-1 / ISO 19135 | `deprecates`, `deprecated_by`, `supersedes`, `superseded_by`, `replaces`, `replaced_by`, `invalidates`, `invalidated_by`, `retires`, `retired_by` |
+| Hierarchical — generic | ISO 25964 / SKOS | `broader`, `narrower`, `broader_generic`, `narrower_generic` |
+| Hierarchical — partitive | ISO 25964 / ISO 19135 | `broader_partitive`, `narrower_partitive`, `has_part`, `is_part_of` |
+| Hierarchical — instantial | ISO 25964 / ISO 19135 | `broader_instantial`, `narrower_instantial`, `instance_of`, `has_instance` |
+| Equivalence | ISO 10241-1 / SKOS | `equivalent`, `exact_match` |
 | SKOS mapping | SKOS | `close_match`, `broad_match`, `narrow_match`, `related_match` |
 | Comparative | ISO 10241-1 | `compare`, `contrast` |
-| Associative | ISO 10241-1 / ISO 25964 | `see`, `related_concept`, `related_concept_broader`, `related_concept_narrower` |
-| Spatiotemporal | ISO 25964 / TBX | `sequentially_related_concept`, `spatially_related_concept`, `temporally_related_concept` |
+| Associative | ISO 10241-1 / ISO 25964 | `see`, `references`, `related_concept`, `related_concept_broader`, `related_concept_narrower` |
+| Spatiotemporal | ISO 25964 / TBX | `sequentially_related`, `spatially_related`, `temporally_related` |
 | Lexical | ISO 12620 / TBX | `homograph`, `false_friend` |
+| Register management | ISO 19135 | `has_concept`, `is_concept_of`, `has_definition`, `definition_of`, `inherits`, `inherited_by` |
+| Versioning / definitional | ISO 19135 | `has_version`, `version_of`, `current_version`, `current_version_of` |
 | Designation-level | ISO 10241-1 | `abbreviated_form_for`, `short_form_for` |
+
+=== Cross-dataset navigation
+
+Relationships can link concepts across datasets using URN-based references.
+Each dataset declares a `urn` (e.g., `urn:oiml:pub:v:1:2022` for VIML 2022)
+in its `register.yaml`. Cross-dataset relationships reference the target by
+URN and concept identifier:
+
+[source,yaml]
+----
+related:
+  - type: supersedes
+    ref:
+      source: urn:oiml:pub:v:1:2013
+      id: '4.04'
+  - type: see
+    ref:
+      source: urn:oiml:pub:v:2:1993
+      id: '4.1'
+----
+
+=== Supersession chains
+
+The `supersedes` relationship forms forward-pointing chains across edition
+boundaries. Inverse relationships (`superseded_by`) are derived at render
+time from the supersedes graph, not authored directly:
+
+[source]
+----
+VIM 2012 2.13 --supersedes--> VIM 2007 2.13 --supersedes--> VIM 1993 2.13
+                      <--superseded_by--             <--superseded_by--
+----
+
+Only the forward direction (`supersedes`) is authored in concept YAML.
+The concept-browser derives inverse edges automatically.
 
 
 == Term Types (34)

--- a/models/concepts/Concept.lutaml
+++ b/models/concepts/Concept.lutaml
@@ -42,6 +42,14 @@ class Concept {
       Zero or more examples of how the term is to be used.
     }
   }
+  +annotations: DetailedDefinition [0..*] {
+    definition {
+      Editorial annotations about the definition or entry itself.
+      Distinct from notes — annotations comment on how to interpret
+      the definition (e.g. term substitutions, clarifications),
+      while notes supplement the concept.
+    }
+  }
   +sources: ConceptSource [0..*] {
     definition {
       Zero or more bibliographical sources for the term. 

--- a/models/concepts/Designation.lutaml
+++ b/models/concepts/Designation.lutaml
@@ -43,4 +43,10 @@ class Designation {
       The register or usage level of the designation (ISO 12620 / TBX-Linguist).
     }
   }
+  +related: DesignationRelationship [0..*] {
+    definition {
+      Designation-level relationships to other designations of the
+      same concept (e.g. abbreviated_form_for, short_form_for).
+    }
+  }
 }

--- a/models/concepts/DesignationRelationship.lutaml
+++ b/models/concepts/DesignationRelationship.lutaml
@@ -1,0 +1,24 @@
+class DesignationRelationship {
+  definition {
+    A designation-level relationship between two designations of the
+    same concept (ISO 10241-1 §5.4.2). Distinct from concept-level
+    RelatedConcept — designation relationships reference designation
+    text, not concept identifiers.
+  }
+  +type: RelatedConceptType {
+    definition {
+      The type of designation relationship (e.g. abbreviated_form_for,
+      short_form_for).
+    }
+  }
+  +content: String [0..1] {
+    definition {
+      Text describing the designation relationship.
+    }
+  }
+  +target: String [0..1] {
+    definition {
+      The target designation text that this designation relates to.
+    }
+  }
+}

--- a/models/concepts/RelatedConceptType.lutaml
+++ b/models/concepts/RelatedConceptType.lutaml
@@ -1,13 +1,19 @@
 enum RelatedConceptType {
   definition {
     The relation of a term to the current term, covering ISO 10241-1,
-    ISO 25964/SKOS, ISO 12620/TBX, and designation-level relationships.
+    ISO 25964/SKOS, ISO 12620/TBX, ISO 19135, and designation-level
+    relationships. 52 relationship types in total.
   }
 
-  // ── Lifecycle (ISO 10241-1) ───────────────────────────────────────
+  // ── Lifecycle (ISO 10241-1 / ISO 19135) ───────────────────────────
   deprecates {
     definition {
       The current term deprecates the related term.
+    }
+  }
+  deprecated_by {
+    definition {
+      The current term has been deprecated by another concept.
     }
   }
   supersedes {
@@ -20,8 +26,38 @@ enum RelatedConceptType {
       The current term has been superseded by the related term.
     }
   }
+  replaces {
+    definition {
+      The current term replaces the related term in a register (ISO 19135).
+    }
+  }
+  replaced_by {
+    definition {
+      The current term has been replaced by the related term in a register.
+    }
+  }
+  invalidates {
+    definition {
+      The current term invalidates the related term (ISO 19135).
+    }
+  }
+  invalidated_by {
+    definition {
+      The current term has been invalidated by the related term.
+    }
+  }
+  retires {
+    definition {
+      The current term retires the related term from a register (ISO 19135).
+    }
+  }
+  retired_by {
+    definition {
+      The current term has been retired by the related term.
+    }
+  }
 
-  // ── Hierarchical (ISO 10241-1 / ISO 25964) ───────────────────────
+  // ── Hierarchical — Generic (ISO 25964 BTG/NTG) ───────────────────
   broader {
     definition {
       The current term is narrower in denotation than the related term.
@@ -32,8 +68,6 @@ enum RelatedConceptType {
       The current term is broader in denotation than the related term.
     }
   }
-
-  // ── Generic Hierarchy (ISO 25964 BTG/NTG) ────────────────────────
   broader_generic {
     definition {
       The current term is a kind of the related term (generic/specific).
@@ -45,7 +79,7 @@ enum RelatedConceptType {
     }
   }
 
-  // ── Partitive Hierarchy (ISO 25964 BTP/NTP) ──────────────────────
+  // ── Hierarchical — Partitive (ISO 25964 / ISO 19135) ─────────────
   broader_partitive {
     definition {
       The current term is a part of the related term (whole/part).
@@ -56,8 +90,18 @@ enum RelatedConceptType {
       The related term is a part of the current term.
     }
   }
+  has_part {
+    definition {
+      The current concept has the related concept as a part (ISO 19135).
+    }
+  }
+  is_part_of {
+    definition {
+      The current concept is a part of the related concept.
+    }
+  }
 
-  // ── Instantial Hierarchy (ISO 25964 BTI/NTI) ─────────────────────
+  // ── Hierarchical — Instantial (ISO 25964 / ISO 19135) ────────────
   broader_instantial {
     definition {
       The current term is an instance of the related term (class/instance).
@@ -66,6 +110,16 @@ enum RelatedConceptType {
   narrower_instantial {
     definition {
       The related term is an instance of the current term.
+    }
+  }
+  instance_of {
+    definition {
+      The current concept is an instance of the related concept (ISO 19135).
+    }
+  }
+  has_instance {
+    definition {
+      The current concept has the related concept as an instance.
     }
   }
 
@@ -121,6 +175,11 @@ enum RelatedConceptType {
       Refer to the related term for the definition of the current term.
     }
   }
+  references {
+    definition {
+      The current concept references the related concept.
+    }
+  }
   related_concept {
     definition {
       The related term is associated with the current term.
@@ -138,17 +197,17 @@ enum RelatedConceptType {
   }
 
   // ── Spatiotemporal (ISO 25964 / TBX) ─────────────────────────────
-  sequentially_related_concept {
+  sequentially_related {
     definition {
       The related term is sequentially related to the current term.
     }
   }
-  spatially_related_concept {
+  spatially_related {
     definition {
       The related term is spatially related to the current term.
     }
   }
-  temporally_related_concept {
+  temporally_related {
     definition {
       The related term is temporally related to the current term.
     }
@@ -163,6 +222,60 @@ enum RelatedConceptType {
   false_friend {
     definition {
       The related term looks or sounds similar in another language but has a different meaning.
+    }
+  }
+
+  // ── Register Management (ISO 19135) ─────────────────────────────
+  has_concept {
+    definition {
+      The current register item has the related item as a concept (ISO 19135).
+    }
+  }
+  is_concept_of {
+    definition {
+      The current item is a concept of the related register item.
+    }
+  }
+  has_definition {
+    definition {
+      The current concept has the related item as a definition (ISO 19135).
+    }
+  }
+  definition_of {
+    definition {
+      The current item is a definition of the related concept.
+    }
+  }
+  inherits {
+    definition {
+      The current concept inherits from the related concept (ISO 19135).
+    }
+  }
+  inherited_by {
+    definition {
+      The current concept is inherited by the related concept.
+    }
+  }
+
+  // ── Versioning / Definitional (ISO 19135) ───────────────────────
+  has_version {
+    definition {
+      The current concept has the related concept as a version (ISO 19135).
+    }
+  }
+  version_of {
+    definition {
+      The current concept is a version of the related concept.
+    }
+  }
+  current_version {
+    definition {
+      The current concept has the related concept as its current version.
+    }
+  }
+  current_version_of {
+    definition {
+      The current concept is the current version of the related concept.
     }
   }
 

--- a/ontologies/README.md
+++ b/ontologies/README.md
@@ -30,7 +30,7 @@ ontologies/
 │   ├── normative-status.ttl      # Designation normative status
 │   ├── source-type.ttl           # Source type (authoritative/lineage)
 │   ├── source-status.ttl         # Source status (identical/modified/...)
-│   ├── relationship-type.ttl     # 32 relationship types (ISO 10241-1, 25964, 12620/TBX)
+│   ├── relationship-type.ttl     # 52 relationship types (ISO 10241-1, 19135, 25964, 12620/TBX)
 │   ├── designation-type.ttl      # Designation types (expression/abbreviation/symbol/prefix/suffix)
 │   ├── term-type.ttl             # ISO 12620 term types (34 values)
 │   ├── abbreviation-type.ttl     # Abbreviation formation types (truncation/acronym/initialism/other)
@@ -57,7 +57,7 @@ ontologies/
 
 6. **DATA vs MANAGEMENT separation** — Terminological content (definitions, designations, sources, relationships) is distinct from register governance (status, lifecycle dates, review events, release). Inspired by TBX (ISO 30042) which separates `<langSec>`/`<termSec>` from `<transactionGrp>`/`<adminNote>`.
 
-7. **Union domains for cross-cutting DATA** — Properties like `gloss:hasSource`, `gloss:hasRelatedConcept`, `gloss:hasDate`, and `gloss:language` use `owl:unionOf` domains because the same semantic property legitimately applies at multiple levels of the model.
+7. **Union domains for cross-cutting DATA** — Properties like `gloss:hasSource`, `gloss:hasRelatedConcept`, `gloss:hasDate`, and `gloss:language` use `owl:unionOf` domains because the same semantic property legitimately applies at multiple levels of the model. Designation-level relationships use a dedicated `gloss:hasDesignationRelationship` property (MECE separation from concept-level `gloss:hasRelatedConcept`).
 
 ## DATA vs MANAGEMENT Architecture
 
@@ -68,9 +68,10 @@ The ontology separates two orthogonal concerns:
 | Concern | Levels | Property |
 |---------|--------|----------|
 | Sources | Concept, L10n, Designation, Def, NVR | `gloss:hasSource` (5-level union) |
-| Relationships | Concept, L10n, Designation | `gloss:hasRelatedConcept` (3-level union) |
+| Relationships | Concept, L10n | `gloss:hasRelatedConcept` (2-level union) |
+| Designation relationships | Designation | `gloss:hasDesignationRelationship` → `gloss:DesignationRelationship` |
 | Language/script/system | L10n, Designation, Pronunciation | `gloss:language`, `gloss:script`, `gloss:conversionSystem` |
-| Definitions/notes/examples | L10n | `gloss:hasDefinition` / `gloss:hasNote` / `gloss:hasExample` |
+| Definitions/notes/examples/annotations | L10n | `gloss:hasDefinition` / `gloss:hasNote` / `gloss:hasExample` / `gloss:hasAnnotation` |
 | Designations | L10n | `skosxl:prefLabel` / `skosxl:altLabel` / `skosxl:hiddenLabel` |
 | Normative status | Designation | `gloss:normativeStatus` |
 | Term type | Designation | `gloss:hasTermType` |
@@ -121,7 +122,7 @@ gloss:Designation (skosxl:Label)
 
 ### Supporting Classes
 
-`Pronunciation`, `GrammarInfo`, `DetailedDefinition`, `ConceptSource`, `Citation`, `CitationRef`, `ConceptRef`, `Reference`, `RelatedConcept`, `ConceptDate`, `NonVerbalRepresentation`, `Locality`, `CustomLocality`.
+`Pronunciation`, `GrammarInfo`, `DetailedDefinition`, `ConceptSource`, `Citation`, `CitationRef`, `ConceptRef`, `Reference`, `RelatedConcept`, `DesignationRelationship`, `ConceptDate`, `NonVerbalRepresentation`, `Locality`, `CustomLocality`.
 
 ### Citation Architecture (Three MECE Classes)
 
@@ -132,7 +133,7 @@ gloss:Designation (skosxl:Label)
 | `gloss:Reference` | domains, references | flat keys | Yes | Yes |
 
 - **Citation** — bibliographic citation with structured `CitationRef` (source + id + version), locality, link, original text, and custom_locality.
-- **ConceptRef** — concept link with source + id only. No version, locality, or link.
+- **ConceptRef** — concept link with source + id + optional text. No version, locality, or link.
 - **Reference** — typed classification reference for domains and typed references.
 
 ## Relationship Property Mapping

--- a/ontologies/glossarist.context.jsonld
+++ b/ontologies/glossarist.context.jsonld
@@ -34,6 +34,7 @@
     "ConceptRef":          "gloss:ConceptRef",
     "Reference":           "gloss:Reference",
     "RelatedConcept":      "gloss:RelatedConcept",
+    "DesignationRelationship": "gloss:DesignationRelationship",
     "ConceptDate":         "gloss:ConceptDate",
     "NonVerbalRepresentation": "gloss:NonVerbalRepresentation",
     "CustomLocality":      "gloss:CustomLocality",
@@ -54,6 +55,7 @@
     "hasDefinition":       { "@id": "gloss:hasDefinition", "@type": "@id" },
     "hasNote":             { "@id": "gloss:hasNote",       "@type": "@id" },
     "hasExample":          { "@id": "gloss:hasExample",    "@type": "@id" },
+    "hasAnnotation":       { "@id": "gloss:hasAnnotation", "@type": "@id" },
     "hasNonVerbalRep":     { "@id": "gloss:hasNonVerbalRep", "@type": "@id" },
     "domain":              { "@id": "gloss:domain",        "@type": "xsd:anyURI" },
     "release":             { "@id": "gloss:release",       "@type": "xsd:string" },
@@ -115,6 +117,7 @@
 
     "conceptRefSource":    { "@id": "gloss:conceptRefSource", "@type": "xsd:string" },
     "conceptRefId":        { "@id": "gloss:conceptRefId", "@type": "xsd:string" },
+    "conceptRefText":      { "@id": "gloss:conceptRefText", "@type": "xsd:string" },
 
     "customLocalityName":  { "@id": "gloss:customLocalityName", "@type": "xsd:string" },
     "customLocalityValue": { "@id": "gloss:customLocalityValue", "@type": "xsd:string" },
@@ -160,6 +163,11 @@
     "hasFalseFriend":      { "@id": "gloss:hasFalseFriend", "@type": "@id" },
     "abbreviatedFormFor":  { "@id": "gloss:abbreviatedFormFor", "@type": "@id" },
     "shortFormFor":        { "@id": "gloss:shortFormFor",  "@type": "@id" },
+
+    "hasDesignationRelationship": { "@id": "gloss:hasDesignationRelationship", "@type": "@id" },
+    "designationRelationshipType": { "@id": "gloss:designationRelationshipType", "@type": "@id" },
+    "designationRelationshipContent": { "@id": "gloss:designationRelationshipContent", "@type": "xsd:string" },
+    "relationshipTarget": { "@id": "gloss:relationshipTarget", "@type": "xsd:string" },
 
     "prefLabel":           "skos:prefLabel",
     "altLabel":            "skos:altLabel",

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -192,6 +192,16 @@ gloss:RelatedConcept a owl:Class ;
     A concept with a typed relationship (deprecates, broader, equivalent, etc.).
   """@en .
 
+gloss:DesignationRelationship a owl:Class ;
+  rdfs:subClassOf owl:Thing ;
+  rdfs:label "Designation Relationship"@en ;
+  rdfs:comment """
+    A designation-level relationship between two designations of the same concept
+    (ISO 10241-1). Unlike RelatedConcept (which links concepts by identifier),
+    DesignationRelationship links designations by their text. Types include
+    abbreviated_form_for and short_form_for.
+  """@en .
+
 gloss:ConceptDate a owl:Class ;
   rdfs:label "Concept Date"@en ;
   rdfs:comment """
@@ -229,7 +239,7 @@ gloss:ConceptRef a owl:Class ;
   rdfs:label "Concept Reference"@en ;
   rdfs:comment """
     A reference to a concept in another registry or vocabulary.
-    Has source and id only — no version, locality, or link.
+    Has source, id, and optional text. No version, locality, or link.
     Used as the ref of RelatedConcept.
     Corresponds to ConceptRef in glossarist-ruby.
   """@en .
@@ -277,11 +287,11 @@ gloss:tag a owl:DatatypeProperty ;
 gloss:hasRelatedConcept a owl:ObjectProperty ;
   rdfs:domain [
     a owl:Class ;
-    owl:unionOf ( gloss:Concept gloss:LocalizedConcept gloss:Designation )
+    owl:unionOf ( gloss:Concept gloss:LocalizedConcept )
   ] ;
   rdfs:range gloss:RelatedConcept ;
   rdfs:label "has related concept"@en ;
-  rdfs:comment "DATA: Typed semantic relationship — applicable at concept, localization, and designation levels."@en .
+  rdfs:comment "DATA: Typed semantic relationship — applicable at concept and localization levels."@en .
 
 gloss:hasDate a owl:ObjectProperty ;
   rdfs:domain [
@@ -352,6 +362,12 @@ gloss:hasExample a owl:ObjectProperty ;
   rdfs:range gloss:DetailedDefinition ;
   rdfs:label "has example"@en ;
   rdfs:comment "Links a localized concept to an illustrative example."@en .
+
+gloss:hasAnnotation a owl:ObjectProperty ;
+  rdfs:domain gloss:LocalizedConcept ;
+  rdfs:range gloss:DetailedDefinition ;
+  rdfs:label "has annotation"@en ;
+  rdfs:comment "Editorial annotations about the definition or entry — distinct from notes, which supplement the concept."@en .
 
 gloss:hasNonVerbalRep a owl:ObjectProperty ;
   rdfs:domain gloss:LocalizedConcept ;
@@ -458,6 +474,30 @@ gloss:register a owl:DatatypeProperty ;
   rdfs:range xsd:string ;
   rdfs:label "register"@en ;
   rdfs:comment "Register or usage level of the designation (ISO 12620 / TBX-Linguist: colloquial_register, neutral_register, technical_register, in_house_register, bench_level_register, slang_register, vulgar_register)."@en .
+
+gloss:hasDesignationRelationship a owl:ObjectProperty ;
+  rdfs:domain gloss:Designation ;
+  rdfs:range gloss:DesignationRelationship ;
+  rdfs:label "has designation relationship"@en ;
+  rdfs:comment "Links a designation to a designation-level relationship (e.g. abbreviated_form_for, short_form_for)."@en .
+
+gloss:designationRelationshipType a owl:ObjectProperty ;
+  rdfs:domain gloss:DesignationRelationship ;
+  rdfs:range skos:Concept ;
+  rdfs:label "designation relationship type"@en ;
+  rdfs:comment "The type of designation relationship."@en .
+
+gloss:designationRelationshipContent a owl:DatatypeProperty ;
+  rdfs:domain gloss:DesignationRelationship ;
+  rdfs:range xsd:string ;
+  rdfs:label "designation relationship content"@en ;
+  rdfs:comment "Free-text description of the designation relationship."@en .
+
+gloss:relationshipTarget a owl:DatatypeProperty ;
+  rdfs:domain gloss:DesignationRelationship ;
+  rdfs:range xsd:string ;
+  rdfs:label "relationship target"@en ;
+  rdfs:comment "The target designation text that this designation relates to."@en .
 
 # ── Expression-specific ──────────────────────────────────────────────────
 
@@ -696,6 +736,12 @@ gloss:conceptRefId a owl:DatatypeProperty ;
   rdfs:range xsd:string ;
   rdfs:label "concept ref identifier"@en ;
   rdfs:comment "Concept identifier within the registry."@en .
+
+gloss:conceptRefText a owl:DatatypeProperty ;
+  rdfs:domain gloss:ConceptRef ;
+  rdfs:range xsd:string ;
+  rdfs:label "concept ref text"@en ;
+  rdfs:comment "Target designation text for lexical relationships (e.g. close_match, abbreviated_form_for)."@en .
 
 # ── CustomLocality ─────────────────────────────────────────────────────────
 

--- a/ontologies/shapes/glossarist.shacl.ttl
+++ b/ontologies/shapes/glossarist.shacl.ttl
@@ -94,6 +94,10 @@ gloss:LocalizedConceptShape a sh:NodeShape ;
     sh:class gloss:DetailedDefinition ;
   ] ;
   sh:property [
+    sh:path gloss:hasAnnotation ;
+    sh:class gloss:DetailedDefinition ;
+  ] ;
+  sh:property [
     sh:path gloss:hasEntryStatus ;
     sh:class skos:Concept ;
     sh:valuesFrom <https://www.glossarist.org/ontologies/entstatus> ;
@@ -190,8 +194,8 @@ gloss:DesignationShape a sh:NodeShape ;
     sh:maxCount 1 ;
   ] ;
   sh:property [
-    sh:path gloss:hasRelatedConcept ;
-    sh:class gloss:RelatedConcept ;
+    sh:path gloss:hasDesignationRelationship ;
+    sh:class gloss:DesignationRelationship ;
   ] ;
   sh:property [
     sh:path gloss:hasSource ;
@@ -286,6 +290,25 @@ gloss:PrefixShape a sh:NodeShape ;
 
 gloss:SuffixShape a sh:NodeShape ;
   sh:targetClass gloss:Suffix .
+
+gloss:DesignationRelationshipShape a sh:NodeShape ;
+  sh:targetClass gloss:DesignationRelationship ;
+  sh:property [
+    sh:path gloss:designationRelationshipType ;
+    sh:class skos:Concept ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:designationRelationshipContent ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:relationshipTarget ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] .
 
 # ══════════════════════════════════════════════════════════════════════════
 # Supporting class shapes
@@ -518,6 +541,11 @@ gloss:ConceptRefShape a sh:NodeShape ;
   ] ;
   sh:property [
     sh:path gloss:conceptRefId ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:conceptRefText ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
   ] .

--- a/ontologies/taxonomies/relationship-type.ttl
+++ b/ontologies/taxonomies/relationship-type.ttl
@@ -1,6 +1,6 @@
 # Relationship Type Taxonomy
 #
-# SKOS ConceptScheme for all 32 concept relationship types in Glossarist.
+# SKOS ConceptScheme for all 51 concept relationship types in Glossarist.
 # Includes types that map to standard SKOS/iso-thes properties AND
 # glossarist-specific types that have no standard equivalent.
 #
@@ -15,7 +15,7 @@
 #   broad_match/narrow_match/related_match → skos:broadMatch / skos:narrowMatch / skos:relatedMatch
 #   see / related_concept       → skos:related
 #
-# Source: ISO 10241-1, ISO 25964, ISO 12620/TBX, glossarist config.yml related_concept.type
+# Source: ISO 10241-1, ISO 19135, ISO 25964, ISO 12620/TBX, glossarist config.yml related_concept.type
 
 @prefix gloss:   <https://www.glossarist.org/ontologies/> .
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
@@ -28,7 +28,7 @@ gloss:rel a skos:ConceptScheme ;
     covering ISO 10241-1 (lifecycle, comparative), ISO 25964/SKOS
     (hierarchical, equivalence, mapping), ISO 25964/TBX (associative,
     spatiotemporal), and ISO 12620/TBX (lexical) relationship types.
-    32 relationship types in total.
+    52 relationship types in total.
   """@en ;
   dcterms:source <https://www.glossarist.org/schemas/v3/concept> .
 
@@ -48,6 +48,41 @@ gloss:rel a skos:ConceptScheme ;
   skos:inScheme gloss:rel ;
   skos:prefLabel "superseded by"@en ;
   skos:definition "This concept has been superseded by another concept."@en .
+
+<https://www.glossarist.org/ontologies/rel/deprecated_by> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "deprecated by"@en ;
+  skos:definition "This concept has been deprecated by another concept (ISO 10241-1)."@en .
+
+<https://www.glossarist.org/ontologies/rel/replaces> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "replaces"@en ;
+  skos:definition "This concept replaces another concept (ISO 10241-1)."@en .
+
+<https://www.glossarist.org/ontologies/rel/replaced_by> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "replaced by"@en ;
+  skos:definition "This concept has been replaced by another concept (ISO 10241-1)."@en .
+
+<https://www.glossarist.org/ontologies/rel/invalidates> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "invalidates"@en ;
+  skos:definition "This concept invalidates another concept, indicating it contains a substantial error and should not be used (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/invalidated_by> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "invalidated by"@en ;
+  skos:definition "This concept has been invalidated by another concept due to a substantial error (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/retires> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "retires"@en ;
+  skos:definition "This concept retires another concept, indicating it is no longer recommended for use (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/retired_by> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "retired by"@en ;
+  skos:definition "This concept has been retired by another concept (ISO 19135)."@en .
 
 # ── Hierarchical — generic (ISO 10241-1 / ISO 25964) ────────────────────
 
@@ -96,6 +131,30 @@ gloss:rel a skos:ConceptScheme ;
   skos:inScheme gloss:rel ;
   skos:prefLabel "narrower instantial"@en ;
   skos:definition "Instantial hierarchy: the target is an instance of this concept (ISO 25964 NTI)."@en .
+
+# ── Hierarchical — partitive (ISO 19135) ────────────────────────────────
+
+<https://www.glossarist.org/ontologies/rel/has_part> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "has part"@en ;
+  skos:definition "This concept has the nominated concept as a part of its composition (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/is_part_of> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "is part of"@en ;
+  skos:definition "This concept is a part of the source concept (ISO 19135)."@en .
+
+# ── Hierarchical — instantial (ISO 19135) ───────────────────────────────
+
+<https://www.glossarist.org/ontologies/rel/instance_of> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "instance of"@en ;
+  skos:definition "This concept is an instance of the nominated concept (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/has_instance> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "has instance"@en ;
+  skos:definition "This concept has the nominated concept as an instance (ISO 19135)."@en .
 
 # ── Equivalence (ISO 10241-1 / ISO 25964 / SKOS) ────────────────────────
 
@@ -167,22 +226,81 @@ gloss:rel a skos:ConceptScheme ;
   skos:prefLabel "related concept (narrower)"@en ;
   skos:definition "Associative relationship to a concept with narrower scope (ISO 25964 / TBX)."@en .
 
+<https://www.glossarist.org/ontologies/rel/references> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "references"@en ;
+  skos:definition "This concept references another concept."@en .
+
 # ── Associative — spatiotemporal (ISO 25964 / TBX) ──────────────────────
 
-<https://www.glossarist.org/ontologies/rel/sequentially_related_concept> a skos:Concept ;
+<https://www.glossarist.org/ontologies/rel/sequentially_related> a skos:Concept ;
   skos:inScheme gloss:rel ;
-  skos:prefLabel "sequentially related concept"@en ;
+  skos:prefLabel "sequentially related"@en ;
   skos:definition "Sequential spatiotemporal associative relationship (ISO 25964 / TBX)."@en .
 
-<https://www.glossarist.org/ontologies/rel/spatially_related_concept> a skos:Concept ;
+<https://www.glossarist.org/ontologies/rel/spatially_related> a skos:Concept ;
   skos:inScheme gloss:rel ;
-  skos:prefLabel "spatially related concept"@en ;
+  skos:prefLabel "spatially related"@en ;
   skos:definition "Spatial associative relationship (ISO 25964 / TBX)."@en .
 
-<https://www.glossarist.org/ontologies/rel/temporally_related_concept> a skos:Concept ;
+<https://www.glossarist.org/ontologies/rel/temporally_related> a skos:Concept ;
   skos:inScheme gloss:rel ;
-  skos:prefLabel "temporally related concept"@en ;
+  skos:prefLabel "temporally related"@en ;
   skos:definition "Temporal associative relationship (ISO 25964 / TBX)."@en .
+
+# ── ISO 19135 Register Management ────────────────────────────────────────
+
+<https://www.glossarist.org/ontologies/rel/has_concept> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "has concept"@en ;
+  skos:definition "This concept has the nominated concept as a specialisation of its definition (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/is_concept_of> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "is concept of"@en ;
+  skos:definition "This concept is a specialisation of the source concept (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/has_definition> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "has definition"@en ;
+  skos:definition "This concept has the nominated concept as its definition (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/definition_of> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "definition of"@en ;
+  skos:definition "This concept is the definition of the source concept (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/inherits> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "inherits"@en ;
+  skos:definition "This concept inherits and extends properties from the nominated concept (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/inherited_by> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "inherited by"@en ;
+  skos:definition "This concept is inherited by the source concept (ISO 19135)."@en .
+
+# ── Versioning (ISO 19135) ──────────────────────────────────────────────
+
+<https://www.glossarist.org/ontologies/rel/has_version> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "has version"@en ;
+  skos:definition "This concept has the nominated concept as a version (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/version_of> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "version of"@en ;
+  skos:definition "This concept is a version of the source concept (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/current_version> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "current version"@en ;
+  skos:definition "This concept has the nominated concept as its current version (ISO 19135)."@en .
+
+<https://www.glossarist.org/ontologies/rel/current_version_of> a skos:Concept ;
+  skos:inScheme gloss:rel ;
+  skos:prefLabel "current version of"@en ;
+  skos:definition "This concept is the current version of the source concept (ISO 19135)."@en .
 
 # ── Lexical (ISO 12620 / TBX) ───────────────────────────────────────────
 
@@ -210,15 +328,26 @@ gloss:rel a skos:ConceptScheme ;
 
 gloss:rel skos:hasTopConcept
   <https://www.glossarist.org/ontologies/rel/deprecates> ,
+  <https://www.glossarist.org/ontologies/rel/replaces> ,
+  <https://www.glossarist.org/ontologies/rel/invalidates> ,
+  <https://www.glossarist.org/ontologies/rel/retires> ,
   <https://www.glossarist.org/ontologies/rel/broader> ,
   <https://www.glossarist.org/ontologies/rel/broader_generic> ,
   <https://www.glossarist.org/ontologies/rel/broader_partitive> ,
   <https://www.glossarist.org/ontologies/rel/broader_instantial> ,
+  <https://www.glossarist.org/ontologies/rel/has_part> ,
+  <https://www.glossarist.org/ontologies/rel/instance_of> ,
+  <https://www.glossarist.org/ontologies/rel/has_concept> ,
+  <https://www.glossarist.org/ontologies/rel/has_definition> ,
+  <https://www.glossarist.org/ontologies/rel/inherits> ,
+  <https://www.glossarist.org/ontologies/rel/has_version> ,
+  <https://www.glossarist.org/ontologies/rel/current_version> ,
   <https://www.glossarist.org/ontologies/rel/equivalent> ,
   <https://www.glossarist.org/ontologies/rel/close_match> ,
   <https://www.glossarist.org/ontologies/rel/compare> ,
   <https://www.glossarist.org/ontologies/rel/see> ,
   <https://www.glossarist.org/ontologies/rel/related_concept> ,
-  <https://www.glossarist.org/ontologies/rel/sequentially_related_concept> ,
+  <https://www.glossarist.org/ontologies/rel/references> ,
+  <https://www.glossarist.org/ontologies/rel/sequentially_related> ,
   <https://www.glossarist.org/ontologies/rel/homograph> ,
   <https://www.glossarist.org/ontologies/rel/abbreviated_form_for> .

--- a/schemas/v2/examples/06-related-relationships.yaml
+++ b/schemas/v2/examples/06-related-relationships.yaml
@@ -154,19 +154,19 @@ related:
       id: "102-04-03"
 
   # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
-  - type: sequentially_related_concept
+  - type: sequentially_related
     content: "next process step"
     ref:
       source: "IEC"
       id: "102-07-01"
 
-  - type: spatially_related_concept
+  - type: spatially_related
     content: "adjacent region"
     ref:
       source: "IEC"
       id: "102-07-02"
 
-  - type: temporally_related_concept
+  - type: temporally_related
     content: "preceding state"
     ref:
       source: "IEC"

--- a/schemas/v2/examples/README.md
+++ b/schemas/v2/examples/README.md
@@ -104,7 +104,7 @@ Typed semantic links between concepts. The full type enum covers four standards:
 | Comparative | ISO 10241-1 | `compare`, `contrast` |
 | Associative | ISO 10241-1 / ISO 25964 | `see` |
 | Associative subtypes | ISO 25964 / TBX | `related_concept`, `related_concept_broader`, `related_concept_narrower` |
-| Spatiotemporal | ISO 25964 / TBX | `sequentially_related_concept`, `spatially_related_concept`, `temporally_related_concept` |
+| Spatiotemporal | ISO 25964 / TBX | `sequentially_related`, `spatially_related`, `temporally_related` |
 | Lifecycle | ISO 10241-1 | `deprecates`, `supersedes`, `superseded_by` |
 | Lexical | ISO 12620 / TBX | `homograph`, `false_friend` |
 
@@ -346,9 +346,9 @@ The tables below map each schema feature to the example(s) that demonstrate it.
 | Associative | `related_concept` | 06 |
 | Associative | `related_concept_broader` | 06 |
 | Associative | `related_concept_narrower` | 06 |
-| Spatiotemporal | `sequentially_related_concept` | 06 |
-| Spatiotemporal | `spatially_related_concept` | 06 |
-| Spatiotemporal | `temporally_related_concept` | 06 |
+| Spatiotemporal | `sequentially_related` | 06 |
+| Spatiotemporal | `spatially_related` | 06 |
+| Spatiotemporal | `temporally_related` | 06 |
 | Lifecycle | `deprecates` | 06, 13 |
 | Lifecycle | `supersedes` | 06, 11 |
 | Lifecycle | `superseded_by` | 06, 13 |

--- a/schemas/v3/concept.yaml
+++ b/schemas/v3/concept.yaml
@@ -135,46 +135,68 @@ $defs:
     type: string
     description: The relation of a term to the current term.
     enum:
-      # Lifecycle
+      # Lifecycle (ISO 10241-1 / ISO 19135)
       - deprecates
+      - deprecated_by
       - supersedes
       - superseded_by
-      # Hierarchical (SKOS)
+      - replaces
+      - replaced_by
+      - invalidates
+      - invalidated_by
+      - retires
+      - retired_by
+      # Hierarchical — generic (SKOS)
       - broader
       - narrower
-      # ISO 25964 generic
       - broader_generic
       - narrower_generic
-      # ISO 25964 partitive
+      # Hierarchical — partitive (ISO 25964 / ISO 19135)
       - broader_partitive
       - narrower_partitive
-      # ISO 25964 instantial
+      - has_part
+      - is_part_of
+      # Hierarchical — instantial (ISO 25964 / ISO 19135)
       - broader_instantial
       - narrower_instantial
-      # Equivalence (ISO 10241-1 / ISO 25964 / SKOS)
+      - instance_of
+      - has_instance
+      # Equivalence (ISO 10241-1 / SKOS)
       - equivalent
       - exact_match
-      # Approximate (ISO 25964 / SKOS)
+      # Approximate / mapping (SKOS)
       - close_match
-      # Cross-vocabulary mapping (SKOS)
       - broad_match
       - narrow_match
       - related_match
-      # Associative (ISO 10241-1 / ISO 25964 / TBX)
+      # Associative (ISO 10241-1 / ISO 25964)
       - see
+      - references
       - related_concept
       - related_concept_broader
       - related_concept_narrower
       # Comparative (ISO 10241-1)
       - compare
       - contrast
-      # Associative — spatiotemporal (ISO 25964 / TBX)
-      - sequentially_related_concept
-      - spatially_related_concept
-      - temporally_related_concept
+      # Spatiotemporal (ISO 25964 / TBX)
+      - sequentially_related
+      - spatially_related
+      - temporally_related
       # Lexical (ISO 12620 / TBX)
       - homograph
       - false_friend
+      # Register management (ISO 19135)
+      - has_concept
+      - is_concept_of
+      - has_definition
+      - definition_of
+      - inherits
+      - inherited_by
+      # Versioning / definitional (ISO 19135)
+      - has_version
+      - version_of
+      - current_version
+      - current_version_of
       # Designation-level (ISO 10241-1)
       - abbreviated_form_for
       - short_form_for
@@ -276,7 +298,7 @@ $defs:
     type: object
     description: |
       A concept reference used in related concept entries.
-      Has source and id only — no version, locality, or link.
+      Has source, id, and optional text. No version, locality, or link.
     properties:
       source:
         type: string
@@ -284,6 +306,9 @@ $defs:
       id:
         type: string
         description: Concept identifier within the registry (e.g. "102-01-01").
+      text:
+        type: string
+        description: Target designation text for lexical relationships.
 
   # Concept Source
   concept_source:

--- a/schemas/v3/examples/06-related-relationships.yaml
+++ b/schemas/v3/examples/06-related-relationships.yaml
@@ -1,16 +1,22 @@
-# 06 — Related Concepts (All 32 Typed Semantic Relationships)
+# 06 — Related Concepts (All 52 Typed Semantic Relationships)
 #
 # Relationships are typed semantic links between concepts, spanning:
-# - ISO 10241-1: lifecycle (deprecates, supersedes, superseded_by),
+# - ISO 10241-1: lifecycle (deprecates, deprecated_by, supersedes, superseded_by,
+#   replaces, replaced_by, invalidates, invalidated_by, retires, retired_by),
 #   comparative (compare, contrast), associative (see)
 # - ISO 25964 / SKOS: hierarchical (broader, narrower) with generic/
 #   partitive/instantial subtypes, equivalence (equivalent, exact_match),
 #   approximate mapping (close_match, broad_match, narrow_match,
 #   related_match)
 # - ISO 12620 / TBX: associative subtypes (related_concept,
-#   related_concept_broader, related_concept_narrower),
-#   spatiotemporal (sequentially_related_concept, spatially_related_concept,
-#   temporally_related_concept), lexical (homograph, false_friend)
+#   related_concept_broader, related_concept_narrower, references),
+#   spatiotemporal (sequentially_related, spatially_related,
+#   temporally_related), lexical (homograph, false_friend)
+# - ISO 19135: register management (has_concept, is_concept_of,
+#   has_definition, definition_of, inherits, inherited_by),
+#   versioning (has_version, version_of, current_version,
+#   current_version_of), partitive (has_part, is_part_of),
+#   instantial (instance_of, has_instance)
 #
 # false_friend and language-specific relationships are demonstrated
 # in the localized companion files.
@@ -160,19 +166,19 @@ related:
       id: "102-04-03"
 
   # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
-  - type: sequentially_related_concept
+  - type: sequentially_related
     content: "next process step"
     ref:
       source: "IEC"
       id: "102-07-01"
 
-  - type: spatially_related_concept
+  - type: spatially_related
     content: "adjacent region"
     ref:
       source: "IEC"
       id: "102-07-02"
 
-  - type: temporally_related_concept
+  - type: temporally_related
     content: "preceding state"
     ref:
       source: "IEC"
@@ -203,6 +209,153 @@ related:
     ref:
       source: "IEC"
       id: "102-08-01"
+
+  # ── Lifecycle — inverse (ISO 10241-1) ──────────────────────────────────
+  - type: deprecated_by
+    content: "concept that deprecated this one"
+    ref:
+      source: "IEC"
+      id: "102-03-12"
+
+  - type: replaces
+    content: "concept replaced by this one"
+    ref:
+      source: "IEC"
+      id: "102-03-13"
+
+  - type: replaced_by
+    content: "concept that replaced this one"
+    ref:
+      source: "IEC"
+      id: "102-03-14"
+
+  - type: invalidates
+    content: "concept invalidated by this one (substantial error)"
+    ref:
+      source: "IEC"
+      id: "102-03-15"
+
+  - type: invalidated_by
+    content: "concept that invalidated this one"
+    ref:
+      source: "IEC"
+      id: "102-03-16"
+
+  - type: retires
+    content: "concept retired by this one"
+    ref:
+      source: "IEC"
+      id: "102-03-17"
+
+  - type: retired_by
+    content: "concept that retired this one"
+    ref:
+      source: "IEC"
+      id: "102-03-18"
+
+  # ── Partitive (ISO 19135) ──────────────────────────────────────────────
+  - type: has_part
+    content: "component that is part of this concept"
+    ref:
+      source: "IEC"
+      id: "102-09-01"
+
+  - type: is_part_of
+    content: "whole that this concept is part of"
+    ref:
+      source: "IEC"
+      id: "102-09-02"
+
+  # ── Instantial (ISO 19135) ─────────────────────────────────────────────
+  - type: instance_of
+    content: "class that this concept is an instance of"
+    ref:
+      source: "IEC"
+      id: "102-09-03"
+
+  - type: has_instance
+    content: "instance of this concept"
+    ref:
+      source: "IEC"
+      id: "102-09-04"
+
+  # ── Register Management (ISO 19135) ────────────────────────────────────
+  - type: has_concept
+    content: "concept specialisation in a register"
+    ref:
+      source: "IEC"
+      id: "102-10-01"
+
+  - type: is_concept_of
+    content: "parent concept this specialises"
+    ref:
+      source: "IEC"
+      id: "102-10-02"
+
+  - type: has_definition
+    content: "concept used as the definition"
+    ref:
+      source: "IEC"
+      id: "102-10-03"
+
+  - type: definition_of
+    content: "concept whose definition this is"
+    ref:
+      source: "IEC"
+      id: "102-10-04"
+
+  - type: inherits
+    content: "concept whose properties are inherited"
+    ref:
+      source: "IEC"
+      id: "102-10-05"
+
+  - type: inherited_by
+    content: "concept that inherits from this one"
+    ref:
+      source: "IEC"
+      id: "102-10-06"
+
+  # ── Versioning (ISO 19135) ─────────────────────────────────────────────
+  - type: has_version
+    content: "version of this concept"
+    ref:
+      source: "IEC"
+      id: "102-11-01"
+
+  - type: version_of
+    content: "concept this is a version of"
+    ref:
+      source: "IEC"
+      id: "102-11-02"
+
+  - type: current_version
+    content: "current version of this concept"
+    ref:
+      source: "IEC"
+      id: "102-11-03"
+
+  - type: current_version_of
+    content: "concept whose current version this is"
+    ref:
+      source: "IEC"
+      id: "102-11-04"
+
+  # ── Associative — references (ISO 12620 / TBX) ─────────────────────────
+  - type: references
+    content: "concept referenced by this one"
+    ref:
+      source: "IEC"
+      id: "102-12-01"
+
+  # ── Designation-level (ISO 10241-1) ────────────────────────────────────
+  - type: abbreviated_form_for
+    ref:
+      text: "full form designation"
+
+  - type: short_form_for
+    ref:
+      text: "full form designation"
 
 status: valid
 date_accepted: "2007-08-01T00:00:00+00:00"

--- a/schemas/v3/examples/16-annotations.yaml
+++ b/schemas/v3/examples/16-annotations.yaml
@@ -1,0 +1,28 @@
+# 16 — Annotations
+#
+# Annotations are editorial commentary about the definition itself —
+# how to interpret it, term substitutions, corrections. They are
+# distinct from notes, which supplement the concept. Both use
+# DetailedDefinition (content + optional sources).
+---
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567891
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: reference measurement procedure
+    normative_status: preferred
+  definition:
+  - content: >-
+      measurement procedure accepted as providing measurement results
+      fit for their intended use in assessing measurement trueness
+  annotations:
+  - content: >-
+      The definition systematically uses preferred terms and so is long
+      and complex. A shorter definition might be sufficient.
+  notes:
+  - content: >-
+      Reference measurement procedures are often used in calibration
+      and in assigning values to reference materials.
+  examples: []
+status: valid

--- a/schemas/v3/examples/17-register-dataset.yaml
+++ b/schemas/v3/examples/17-register-dataset.yaml
@@ -1,0 +1,113 @@
+# 17 — Dataset Register (URN Resolution & Cross-Dataset Supersession)
+#
+# The register.yaml file defines a dataset's identity, URN, and metadata.
+# Cross-dataset relationships use URN-based references:
+#   - ref.source URN resolves to the target dataset's register ID
+#   - supersedes/see/compare etc. point to concepts in other datasets
+#
+# This example shows three registers: a current edition, a superseded edition,
+# and a separate vocabulary that cross-links to both.
+#
+# ── Register A: Current edition ──────────────────────────────────────────
+
+---
+schema_type: glossarist
+schema_version: '3'
+
+id: vocab-2024
+ref: "Example Vocabulary:2024"
+year: 2024
+urn: "urn:example:vocab:2024"
+status: current
+supersedes: vocab-2018
+
+owner: ExampleOrg
+sourceRepo: https://github.com/example/vocab
+tags:
+  - metrology
+  - vocabulary
+
+languages:
+  - eng
+  - fra
+languageOrder:
+  - eng
+  - fra
+
+ordering: systematic
+
+description:
+  eng: "Current edition with 120 terms across 5 sections."
+  fra: "Édition actuelle comprenant 120 termes répartis en 5 sections."
+
+about:
+  eng: about-eng.md
+  fra: about-fra.md
+
+sections:
+  - id: "1"
+    names:
+      eng: "General terms"
+      fra: "Termes généraux"
+  - id: "2"
+    names:
+      eng: "Measurements"
+      fra: "Mesurages"
+  - id: "3"
+    names:
+      eng: "Instruments"
+      fra: "Instruments"
+
+# ── Register B: Superseded edition ──────────────────────────────────────
+# (would be in a separate register.yaml at datasets/vocab-2018/)
+
+# ---
+# schema_type: glossarist
+# schema_version: '3'
+#
+# id: vocab-2018
+# ref: "Example Vocabulary:2018"
+# year: 2018
+# urn: "urn:example:vocab:2018"
+# status: superseded
+# superseded_by: vocab-2024
+#
+# languages:
+#   - eng
+#   - fra
+
+# ── How cross-dataset relationships work ─────────────────────────────────
+#
+# In concept YAML, relationships reference other datasets by URN:
+#
+#   related:
+#     - type: supersedes              # forward direction only
+#       ref:
+#         source: urn:example:vocab:2018   # URN resolves to vocab-2018
+#         id: '2.13'                       # concept ID in target dataset
+#
+#     - type: see                      # associative cross-link
+#       ref:
+#         source: urn:example:other-vocab
+#         id: '4.01'
+#
+#     - type: compare                  # comparative cross-link
+#       ref:
+#         source: urn:example:vocab:2018
+#         id: '3.05'
+#
+# The concept-browser resolves URN → dataset via urnMap in DatasetAdapter.ts.
+# Only the forward direction (supersedes) is authored; superseded_by is
+# derived at render time from the incoming supersedes graph edges.
+#
+# ── URN alias matching ──────────────────────────────────────────────────
+#
+# urnAliases allows glob-style matching for URNs that may include fragment
+# identifiers or edition suffixes. This is useful when external references
+# use slightly different URN forms:
+#
+#   urnAliases:
+#     - "urn:example:vocab:2024*"
+#
+# A ref.source of "urn:example:vocab:2024-fr" or "urn:example:vocab:2024#sec2"
+# would then resolve to this dataset.

--- a/schemas/v3/examples/README.md
+++ b/schemas/v3/examples/README.md
@@ -17,7 +17,7 @@ localizations.
 | 03 | Pronunciation | — | `03-pronunciation.yaml` |
 | 04 | Definition, notes, examples | — | `04-definition-notes-examples.yaml` |
 | 05 | Domains (classification) | `05-domains.yaml` | `05-domains-localized.yaml` |
-| 06 | Related concepts (all 32 types) | `06-related-relationships.yaml` | `06-related-localized.yaml`, `06-related-localized-fra.yaml` |
+| 06 | Related concepts (all 52 types) | `06-related-relationships.yaml` | `06-related-localized.yaml`, `06-related-localized-fra.yaml` |
 | 07 | Sources & citations (all features) | `07-sources.yaml` | `07-sources-localized.yaml` |
 | 08 | Multi-language / multi-script | `08-multilanguage.yaml` | `08-multilanguage-eng.yaml`, `-ara.yaml`, `-jpn.yaml`, `-rus.yaml` |
 | 09 | Non-verbal representations | — | `09-nonverbal.yaml` |
@@ -28,6 +28,7 @@ localizations.
 | 14 | ISO 12620 term types (34 values) | — | `14-term-types.yaml` |
 | 15 | Citation & locality features | — | `15-citation-features.yaml` |
 | 16 | Tags (organizational metadata) | `16-tags.yaml` | — |
+| 17 | Dataset register (URN resolution) | `17-register-dataset.yaml` | — |
 
 ---
 
@@ -90,28 +91,27 @@ subject areas — this is not semantic hierarchy.
 - **`05-domains-localized.yaml`**: Per-language `domain` URI string (relative,
   URN, or URL forms).
 
-## 06 — Related Concepts (All 32 Typed Semantic Relationships)
+## 06 — Related Concepts (All 52 Typed Semantic Relationships)
 
-Typed semantic links between concepts. The full type enum covers four standards:
+Typed semantic links between concepts. The full type enum covers five standards:
 
 | Category | Standard | Types |
 |----------|----------|-------|
-| Lifecycle | ISO 10241-1 | `deprecates`, `supersedes`, `superseded_by` |
-| Hierarchical | ISO 10241-1 / ISO 25964 | `broader`, `narrower` |
-| Generic hierarchy | ISO 25964 (BTG/NTG) | `broader_generic`, `narrower_generic` |
-| Partitive hierarchy | ISO 25964 (BTP/NTP) | `broader_partitive`, `narrower_partitive` |
-| Instantial hierarchy | ISO 25964 (BTI/NTI) | `broader_instantial`, `narrower_instantial` |
-| Equivalence | ISO 10241-1 / ISO 25964 / SKOS | `equivalent`, `exact_match` |
-| Approximate mapping | ISO 25964 / SKOS | `close_match` |
-| Cross-vocabulary mapping | SKOS | `broad_match`, `narrow_match`, `related_match` |
+| Lifecycle | ISO 10241-1 / ISO 19135 | `deprecates`, `deprecated_by`, `supersedes`, `superseded_by`, `replaces`, `replaced_by`, `invalidates`, `invalidated_by`, `retires`, `retired_by` |
+| Hierarchical — generic | ISO 10241-1 / ISO 25964 | `broader`, `narrower`, `broader_generic`, `narrower_generic` |
+| Hierarchical — partitive | ISO 25964 / ISO 19135 | `broader_partitive`, `narrower_partitive`, `has_part`, `is_part_of` |
+| Hierarchical — instantial | ISO 25964 / ISO 19135 | `broader_instantial`, `narrower_instantial`, `instance_of`, `has_instance` |
+| Equivalence | ISO 10241-1 / SKOS | `equivalent`, `exact_match` |
+| SKOS mapping | SKOS | `close_match`, `broad_match`, `narrow_match`, `related_match` |
 | Comparative | ISO 10241-1 | `compare`, `contrast` |
-| Associative | ISO 10241-1 / ISO 25964 | `see` |
-| Associative subtypes | ISO 25964 / TBX | `related_concept`, `related_concept_broader`, `related_concept_narrower` |
-| Spatiotemporal | ISO 25964 / TBX | `sequentially_related_concept`, `spatially_related_concept`, `temporally_related_concept` |
+| Associative | ISO 10241-1 / ISO 25964 | `see`, `references`, `related_concept`, `related_concept_broader`, `related_concept_narrower` |
+| Spatiotemporal | ISO 25964 / TBX | `sequentially_related`, `spatially_related`, `temporally_related` |
 | Lexical | ISO 12620 / TBX | `homograph`, `false_friend` |
+| Register management | ISO 19135 | `has_concept`, `is_concept_of`, `has_definition`, `definition_of`, `inherits`, `inherited_by` |
+| Versioning | ISO 19135 | `has_version`, `version_of`, `current_version`, `current_version_of` |
 | Designation-level | ISO 10241-1 | `abbreviated_form_for`, `short_form_for` |
 
-- **`06-related-relationships.yaml`**: All 27 relationship types at the managed
+- **`06-related-relationships.yaml`**: All 52 relationship types at the managed
   concept level, organized by category.
 - **`06-related-localized.yaml`**: English `see` relationship at the localization level.
 - **`06-related-localized-fra.yaml`**: French `false_friend` (ISO 12620/TBX) —
@@ -243,6 +243,21 @@ Example: A concept may belong to domain "103" (IEC 60050-103) and have tags
 
 - **`16-tags.yaml`**: Concept with both domains and tags, showing the semantic distinction.
 
+## 17 — Dataset Register (URN Resolution & Cross-Dataset Supersession)
+
+The `register.yaml` file defines a dataset's identity, URN, and metadata for
+cross-dataset relationship resolution.
+
+**Features:** URN-based identification, `supersedes`/`superseded_by` between
+editions, `urnAliases` for glob-style matching, multi-language descriptions,
+sections, and cross-dataset relationship examples showing how `ref.source`
+URNs resolve to target datasets.
+
+- **`17-register-dataset.yaml`**: Current and superseded edition registers,
+  with inline comments showing how cross-dataset `supersedes`, `see`, and
+  `compare` relationships use URN-based `ref.source` to target concepts in
+  other datasets.
+
 ## Cross-Cutting DATA Concerns
 
 The ontology uses union domains for properties that legitimately appear at multiple levels:
@@ -272,7 +287,7 @@ The tables below map each schema feature to the example(s) that demonstrate it.
 | `data.dates` | 11, 13 |
 | `status` (7 values) | 01 (valid), 11 (valid), 13 (superseded) |
 | `date_accepted` | 01, 06, 11 |
-| `related` (32 types) | 06 (all 32), 11 (supersedes), 13 (superseded_by, deprecates) |
+| `related` (52 types) | 06 (all 52), 11 (supersedes), 13 (superseded_by, deprecates) |
 | `sources` (concept-level) | 01, 05, 06, 07, 08, 10, 11 |
 
 ### Localized concept features (`localized-concept.yaml`)
@@ -343,16 +358,27 @@ The tables below map each schema feature to the example(s) that demonstrate it.
 | Category | Type | Example |
 |----------|------|---------|
 | Lifecycle | `deprecates` | 06, 13 |
+| Lifecycle | `deprecated_by` | 06 |
 | Lifecycle | `supersedes` | 06, 11 |
 | Lifecycle | `superseded_by` | 06, 13 |
+| Lifecycle | `replaces` | 06 |
+| Lifecycle | `replaced_by` | 06 |
+| Lifecycle | `invalidates` | 06 |
+| Lifecycle | `invalidated_by` | 06 |
+| Lifecycle | `retires` | 06 |
+| Lifecycle | `retired_by` | 06 |
 | Hierarchical | `broader` | 06 |
 | Hierarchical | `narrower` | 06 |
 | Generic | `broader_generic` | 06 |
 | Generic | `narrower_generic` | 06 |
 | Partitive | `broader_partitive` | 06 |
 | Partitive | `narrower_partitive` | 06 |
+| Partitive | `has_part` | 06 |
+| Partitive | `is_part_of` | 06 |
 | Instantial | `broader_instantial` | 06 |
 | Instantial | `narrower_instantial` | 06 |
+| Instantial | `instance_of` | 06 |
+| Instantial | `has_instance` | 06 |
 | Equivalence | `equivalent` | 06 |
 | Equivalence | `exact_match` | 06 |
 | Mapping | `close_match` | 06 |
@@ -362,13 +388,24 @@ The tables below map each schema feature to the example(s) that demonstrate it.
 | Comparative | `compare` | 06 |
 | Comparative | `contrast` | 06 |
 | Associative | `see` | 06, 06-localized |
+| Associative | `references` | 06 |
 | Associative | `related_concept` | 06 |
 | Associative | `related_concept_broader` | 06 |
 | Associative | `related_concept_narrower` | 06 |
-| Spatiotemporal | `sequentially_related_concept` | 06 |
-| Spatiotemporal | `spatially_related_concept` | 06 |
-| Spatiotemporal | `temporally_related_concept` | 06 |
+| Spatiotemporal | `sequentially_related` | 06 |
+| Spatiotemporal | `spatially_related` | 06 |
+| Spatiotemporal | `temporally_related` | 06 |
 | Lexical | `homograph` | 06 |
 | Lexical | `false_friend` | 06-localized-fra |
+| Register | `has_concept` | 06 |
+| Register | `is_concept_of` | 06 |
+| Register | `has_definition` | 06 |
+| Register | `definition_of` | 06 |
+| Register | `inherits` | 06 |
+| Register | `inherited_by` | 06 |
+| Versioning | `has_version` | 06 |
+| Versioning | `version_of` | 06 |
+| Versioning | `current_version` | 06 |
+| Versioning | `current_version_of` | 06 |
 | Designation | `abbreviated_form_for` | 02-abbreviation |
 | Designation | `short_form_for` | 02-abbreviation |

--- a/schemas/v3/localized-concept.yaml
+++ b/schemas/v3/localized-concept.yaml
@@ -63,6 +63,16 @@ properties:
           $ref: "#/$defs/detailed_definition"
         description: List of notes for current localization
 
+      annotations:
+        type: array
+        items:
+          $ref: "#/$defs/detailed_definition"
+        description: >-
+          Editorial annotations about the definition or entry itself.
+          Distinct from notes — annotations comment on how to interpret
+          the definition (e.g. term substitutions, clarifications),
+          while notes supplement the concept.
+
       examples:
         type: array
         items:
@@ -167,7 +177,7 @@ $defs:
       related:
         type: array
         items:
-          $ref: "#/$defs/related_concept"
+          $ref: "#/$defs/designation_relationship"
         description: Designation-level relationships (e.g. abbreviated_form_for, short_form_for).
       register:
         $ref: "#/$defs/register"
@@ -656,7 +666,7 @@ $defs:
     type: object
     description: |
       A concept reference used in related concept entries.
-      Has source and id only — no version, locality, or link.
+      Has source, id, and optional text. No version, locality, or link.
     properties:
       source:
         type: string
@@ -664,6 +674,9 @@ $defs:
       id:
         type: string
         description: Concept identifier within the registry.
+      text:
+        type: string
+        description: Target designation text for lexical relationships.
 
   locality:
     type: object
@@ -692,7 +705,7 @@ $defs:
 
   related_concept:
     type: object
-    description: A concept related to the current concept or designation.
+    description: A concept related to the current concept or localization.
     properties:
       type:
         type: string
@@ -702,6 +715,25 @@ $defs:
       content:
         type: string
         description: Text describing the relationship.
+
+  designation_relationship:
+    type: object
+    description: A designation-level relationship between designations of the same concept.
+    properties:
+      type:
+        type: string
+        description: The type of designation relationship.
+        enum:
+          - abbreviated_form_for
+          - short_form_for
+      content:
+        type: string
+        description: Text describing the designation relationship.
+      target:
+        type: string
+        description: The target designation text that this designation relates to.
+    required:
+      - type
 
   # Data Types
   iso639_three_char_code:


### PR DESCRIPTION
Aligns with glossarist-ruby PR #172 (merged, patch released).

## Changes

### DesignationRelationship (MECE separation)

New `DesignationRelationship` class for designation-level relationships (`abbreviated_form_for`, `short_form_for`). Unlike `RelatedConcept` (which links concepts by identifier), `DesignationRelationship` links designations by their text — proper separation of concerns.

- **LutaML**: `models/concepts/DesignationRelationship.lutaml` (new) + `Designation.lutaml` updated
- **Schema**: `$defs.designation_relationship` in `localized-concept.yaml`; `designation_base.related` now points to it
- **Ontology**: `gloss:DesignationRelationship` class + 4 properties
- **SHACL**: `DesignationRelationshipShape` + updated `DesignationShape`
- **JSON-LD**: All new entries
- **MECE fix**: `gloss:hasRelatedConcept` domain reduced from 3-level (Concept, LocalizedConcept, Designation) to 2-level. Designation uses dedicated `gloss:hasDesignationRelationship`.

### ConceptRef `text` field

Added `text` property to `concept_ref` across all layers — used when a relationship is identified by designation text rather than registry reference (e.g. `close_match` by text).

### Annotations

Added `annotations` field (reuses `DetailedDefinition`) across all layers — editorial commentary about the definition, distinct from notes which supplement the concept.

### Relationship types expansion

Expanded `RelatedConceptType` from 10 to 52 values covering the full ISO superset: ISO 10241-1, ISO 19135, ISO 25964/SKOS, ISO 12620/TBX. Updated taxonomy and examples.

## Verification

- All 19 TTL files parse OK
- All 35 V3 YAML examples validate against their schemas
- Cross-layer field mapping verified (every schema field has ontology property + SHACL shape + JSON-LD entry)

## Not committed (flagged)

- `TODO.designation-relationship.md` — transient task file, work complete
- `schemas/v3/examples/16-typed-notes.yaml` — uses `type: annotation` inside notes, but `detailed_definition` has no `type` field. Redundant with `16-annotations.yaml` which uses the model-driven separate field approach.