### PR TITLE
feat: add ConceptSource#id for inline cite:key references

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,9 @@ In particular, the following features are supported.
 * Single domain (per localized concept)
 * Multiple domains (concept-level `ConceptReference` collection)
 * Multiple tags (concept-level organizational labels, not rendered as domains)
-* Multiple sources
+* Multiple sources (with optional `id` for inline `{{cite:<id>}}` references)
+* Annotations (editorial comments distinct from notes)
+* Designation-level relationships (`abbreviated_form_for`, `short_form_for`)
 
 Paragraph/TextElement may contain a formula.
 
@@ -222,8 +224,97 @@ The TC 204 Geolexica site is an example of this: the entire glossary represents
 ISO 14812 terminology, so the authoritative source for every entry is the
 glossary itself.
 
+=== Inline citation references (`{{cite:<id>}}`)
+
+Each `ConceptSource` may carry an optional `id` — a stable, locally-unique key
+that can be referenced by inline `{{cite:<id>}}` mentions in the concept's text
+(definitions, notes, examples). The `id` must be unique within the concept's
+entire sources list (across concept-level, localization-level, and
+designation-level sources).
+
+When a source has an `id`, inline mentions of the form `{{cite:<id>}}` resolve
+to that source's `origin` citation. Resolution is deployment-dependent:
+
+Self-contained::
+The inline citation renders as a flat reference (origin.ref, locality, link).
+
+Co-deployed::
+If the deployment has a bibliographic dataset registered under the same
+`Citation::Ref.source` (e.g. `bibliography:ISO`), the citation resolves to the
+rich bibliographic record. The inline locality (if any) is shown as the
+specific point of reference.
+
+External::
+A URI form (e.g. `urn:iso:std:iso:7301:2024`) with no co-deployed match renders
+as the URI as a link.
+
+A source without an `id` is not referenceable by inline mentions; it is rendered
+only as the concept's "sourced from" relationship.
+
+Example:
+
+[source,yaml]
+----
+sources:
+  - id: iso7301
+    type: authoritative
+    origin:
+      ref:
+        source: ISO
+        id: "7301:2024"
+  - type: lineage
+    origin:
+      ref:
+        source: ISO
+        id: "7301:1995"
+----
+
+The concept's definition text can then reference the source inline:
+
+....
+Rice grains are classified according to `{{cite:iso7301}}`.
+....
+
 NOTE: The `ConceptSource` model is shown in the <<ConceptSource>> UML diagram
 below.
+
+
+== Designation relationships
+
+The `DesignationRelationship` model captures designation-level relationships
+between two designations of the same concept (ISO 10241-1 §5.4.2). Unlike
+concept-level relationships (`RelatedConcept`), which link concepts by
+identifier, designation relationships link designations by their text.
+
+Each relationship has:
+
+`type`:: The relationship type (`abbreviated_form_for`, `short_form_for`).
+`content`:: Optional free-text describing the relationship.
+`target`:: The target designation text that this designation relates to.
+
+Example:
+
+[source,yaml]
+----
+designations:
+  - type: expression
+    designation: International System of Units
+  - type: abbreviation
+    designation: SI
+    related:
+      - type: abbreviated_form_for
+        target: "International System of Units"
+----
+
+
+== Annotations
+
+Annotations are editorial comments about the definition or entry itself,
+distinct from notes. Notes supplement the concept; annotations comment on how
+to interpret the definition (e.g. term substitutions, clarifications).
+
+Annotations use the same `DetailedDefinition` structure as definitions, notes,
+and examples, with `content` and optional per-item `sources`.
 
 
 == UML Models

--- a/models/concepts/ConceptSource.lutaml
+++ b/models/concepts/ConceptSource.lutaml
@@ -1,6 +1,25 @@
 class ConceptSource {
   definition {
-    Bibliographic source for a managed term.
+    Bibliographic source for a managed term. May carry an
+    optional `id` for inline reference via {{cite:<id>}}
+    mentions in the concept's text.
+  }
+  +id: String [0..1] {
+    definition {
+      Optional stable identifier for the source, used by
+      inline `{{cite:<id>}}` references in the concept's text.
+      The id is local to the concept; it must be unique within
+      the concept's sources list (across concept-level,
+      localization-level, and designation-level sources).
+
+      A source with an id can be referenced by inline mentions
+      using the `{{cite:<id>}}` form. The mention resolves to
+      this source's Citation (origin.ref + locality + link).
+
+      A source without an id is not referenceable by inline
+      mentions; it is rendered only as the concept's "sourced
+      from" relationship.
+    }
   }
   +status: ConceptSourceStatus {
     definition {

--- a/ontologies/glossarist.context.jsonld
+++ b/ontologies/glossarist.context.jsonld
@@ -103,6 +103,7 @@
 
     "sourceType":          { "@id": "gloss:sourceType",    "@type": "@id" },
     "sourceStatus":        { "@id": "gloss:sourceStatus",  "@type": "@id" },
+    "sourceId":            { "@id": "gloss:sourceId",      "@type": "xsd:string" },
     "sourceOrigin":        { "@id": "gloss:sourceOrigin",  "@type": "@id" },
     "modification":        { "@id": "gloss:modification",  "@type": "xsd:string" },
 

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -653,6 +653,16 @@ gloss:term a owl:DatatypeProperty ;
 # OBJECT PROPERTIES — Source
 # ══════════════════════════════════════════════════════════════════════════
 
+gloss:sourceId a owl:DatatypeProperty ;
+  rdfs:domain gloss:ConceptSource ;
+  rdfs:range xsd:string ;
+  rdfs:label "source id"@en ;
+  rdfs:comment """
+    Optional stable identifier for the source, used by inline
+    `{{cite:<id>}}` references. Local to the concept; must be
+    unique within the concept's sources list.
+  """@en .
+
 gloss:sourceType a owl:ObjectProperty ;
   rdfs:domain gloss:ConceptSource ;
   rdfs:range skos:Concept ;
@@ -676,6 +686,28 @@ gloss:modification a owl:DatatypeProperty ;
   rdfs:range xsd:string ;
   rdfs:label "modification"@en ;
   rdfs:comment "How the concept was modified from the source."@en .
+
+# ── Citation resolution ────────────────────────────────────────────────────
+#
+# An inline `{{cite:<id>}}` mention in a concept's text
+# resolves to a Citation (ConceptSource#origin) in the same
+# concept's sources list. The resolution is deployment-
+# dependent:
+#
+#   1. Self-contained: the inline Citation is rendered as a
+#      flat citation (the source's origin.ref, locality, link).
+#   2. Co-deployed: if the deployment has a bibliographic
+#      dataset registered under the same `Citation::Ref.source`
+#      (e.g. 'bibliography:ISO'), the citation is resolved to
+#      the rich bibliographic record. The inline locality
+#      (if any) is shown as the specific point of reference.
+#   3. External: a URI form (e.g. `urn:iso:std:iso:7301:2024`)
+#      with no co-deployed match renders as the URI as a link.
+#
+# The Reference data structure (extracted by glossarist-js or
+# glossarist-ruby) carries the URI/lookupKey/cite-key;
+# resolution against the deployment's bibliography registry
+# happens at render time.
 
 # ── Citation properties ────────────────────────────────────────────────────
 

--- a/ontologies/shapes/glossarist.shacl.ttl
+++ b/ontologies/shapes/glossarist.shacl.ttl
@@ -358,6 +358,11 @@ gloss:DetailedDefinitionShape a sh:NodeShape ;
 gloss:ConceptSourceShape a sh:NodeShape ;
   sh:targetClass gloss:ConceptSource ;
   sh:property [
+    sh:path gloss:sourceId ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
     sh:path gloss:sourceType ;
     sh:class skos:Concept ;
     sh:valuesFrom <https://www.glossarist.org/ontologies/srctype> ;

--- a/schemas/v3/concept.yaml
+++ b/schemas/v3/concept.yaml
@@ -313,8 +313,20 @@ $defs:
   # Concept Source
   concept_source:
     type: object
-    description: Bibliographic reference for a concept or designation
+    description: |
+      Bibliographic reference for a concept or designation.
+      May carry an optional `id` for inline reference via
+      `{{cite:<id>}}` mentions in the concept's text.
     properties:
+      id:
+        type: string
+        description: |
+          Optional stable identifier for the source, used by
+          inline `{{cite:<id>}}` references in the concept's
+          text. The id is local to the concept; it must be
+          unique within the concept's sources list (across
+          concept-level, localization-level, and
+          designation-level sources).
       type:
         $ref: "#/$defs/concept_source_type"
       status:

--- a/schemas/v3/localized-concept.yaml
+++ b/schemas/v3/localized-concept.yaml
@@ -558,8 +558,17 @@ $defs:
 
   concept_source:
     type: object
-    description: Bibliographic reference for a concept or designation
+    description: |
+      Bibliographic reference for a concept or designation.
+      May carry an optional `id` for inline reference via
+      `{{cite:<id>}}` mentions in the concept's text.
     properties:
+      id:
+        type: string
+        description: |
+          Optional stable identifier for the source, used by
+          inline `{{cite:<id>}}` references in the concept's
+          text.
       status:
         $ref: "#/$defs/concept_source_statuses"
       type:


### PR DESCRIPTION
## Summary

Add an optional `id` field to `ConceptSource` for inline `{{cite:<id>}}` mention references in concept text (definitions, notes, examples).

A source with an `id` can be referenced from concept text using `{{cite:<id>}}` syntax. Resolution is deployment-dependent:
- **Self-contained**: renders as a flat citation (origin.ref, locality, link)
- **Co-deployed**: resolves to a rich bibliographic record if a matching dataset is registered
- **External**: renders as a URI link when no co-deployed match exists

## Changes (7 files, all layers in sync)

| Layer | File | Change |
|---|---|---|
| Lutaml model | `ConceptSource.lutaml` | `+id: String [0..1]` with definition |
| YAML schema (concept) | `concept.yaml` | `id` in `.concept_source` |
| YAML schema (localized) | `localized-concept.yaml` | `id` in `.concept_source` |
| OWL ontology | `glossarist.ttl` | `gloss:sourceId` DatatypeProperty + citation resolution docs |
| SHACL shapes | `glossarist.shacl.ttl` | `sourceId` constraint on `ConceptSourceShape` |
| JSON-LD context | `glossarist.context.jsonld` | `"sourceId"` mapping |
| README | `README.adoc` | Docs for cite:key, DesignationRelationship, annotations |

## Acceptance criteria

- [x] `ConceptSource.lutaml` includes the `+id` field
- [x] Both YAML schemas include `id` in `.concept_source`
- [x] Ontology includes `gloss:sourceId` property and citation resolution semantics
- [x] SHACL shape includes `sourceId` constraint
- [x] JSON-LD context includes `sourceId` mapping
- [x] README documents the feature
- [x] All six representation layers are updated in sync