### PR TITLE
fix: correct cite inline reference syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ In particular, the following features are supported.
 * Single domain (per localized concept)
 * Multiple domains (concept-level `ConceptReference` collection)
 * Multiple tags (concept-level organizational labels, not rendered as domains)
-* Multiple sources (with optional `id` for inline `{{cite:<id>}}` references)
+* Multiple sources (with optional `id` for inline `{{cite:id}}` references)
 * Annotations (editorial comments distinct from notes)
 * Designation-level relationships (`abbreviated_form_for`, `short_form_for`)
 
@@ -224,16 +224,20 @@ The TC 204 Geolexica site is an example of this: the entire glossary represents
 ISO 14812 terminology, so the authoritative source for every entry is the
 glossary itself.
 
-=== Inline citation references (`{{cite:<id>}}`)
+=== Inline citation references (`{{cite:id}}`)
 
 Each `ConceptSource` may carry an optional `id` — a stable, locally-unique key
-that can be referenced by inline `{{cite:<id>}}` mentions in the concept's text
+that can be referenced by inline `{{cite:id}}` mentions in the concept's text
 (definitions, notes, examples). The `id` must be unique within the concept's
 entire sources list (across concept-level, localization-level, and
 designation-level sources).
 
-When a source has an `id`, inline mentions of the form `{{cite:<id>}}` resolve
-to that source's `origin` citation. Resolution is deployment-dependent:
+The inline mention syntax is `{{cite:id}}` (without render term) or
+`{{cite:id,render term}}` (with render term). The id always comes first;
+the render term, if present, always comes last.
+
+When a source has an `id`, inline mentions resolve to that source's `origin`
+citation. Resolution is deployment-dependent:
 
 Self-contained::
 The inline citation renders as a flat reference (origin.ref, locality, link).
@@ -272,7 +276,8 @@ sources:
 The concept's definition text can then reference the source inline:
 
 ....
-Rice grains are classified according to `{{cite:iso7301}}`.
+Rice grains are classified according to {{cite:iso7301}}.
+Rice grains are classified according to {{cite:iso7301,ISO 7301:2024}}.
 ....
 
 NOTE: The `ConceptSource` model is shown in the <<ConceptSource>> UML diagram

--- a/models/concepts/ConceptSource.lutaml
+++ b/models/concepts/ConceptSource.lutaml
@@ -1,19 +1,19 @@
 class ConceptSource {
   definition {
     Bibliographic source for a managed term. May carry an
-    optional `id` for inline reference via {{cite:<id>}}
+    optional `id` for inline reference via {{cite:id}}
     mentions in the concept's text.
   }
   +id: String [0..1] {
     definition {
       Optional stable identifier for the source, used by
-      inline `{{cite:<id>}}` references in the concept's text.
+      inline `{{cite:id}}` references in the concept's text.
       The id is local to the concept; it must be unique within
       the concept's sources list (across concept-level,
       localization-level, and designation-level sources).
 
       A source with an id can be referenced by inline mentions
-      using the `{{cite:<id>}}` form. The mention resolves to
+      using the `{{cite:id}}` form. The mention resolves to
       this source's Citation (origin.ref + locality + link).
 
       A source without an id is not referenceable by inline

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -659,7 +659,7 @@ gloss:sourceId a owl:DatatypeProperty ;
   rdfs:label "source id"@en ;
   rdfs:comment """
     Optional stable identifier for the source, used by inline
-    `{{cite:<id>}}` references. Local to the concept; must be
+    `{{cite:id}}` references. Local to the concept; must be
     unique within the concept's sources list.
   """@en .
 
@@ -689,7 +689,7 @@ gloss:modification a owl:DatatypeProperty ;
 
 # ── Citation resolution ────────────────────────────────────────────────────
 #
-# An inline `{{cite:<id>}}` mention in a concept's text
+# An inline `{{cite:id}}` mention in a concept's text
 # resolves to a Citation (ConceptSource#origin) in the same
 # concept's sources list. The resolution is deployment-
 # dependent:

--- a/schemas/v3/concept.yaml
+++ b/schemas/v3/concept.yaml
@@ -316,13 +316,13 @@ $defs:
     description: |
       Bibliographic reference for a concept or designation.
       May carry an optional `id` for inline reference via
-      `{{cite:<id>}}` mentions in the concept's text.
+      `{{cite:id}}` mentions in the concept's text.
     properties:
       id:
         type: string
         description: |
           Optional stable identifier for the source, used by
-          inline `{{cite:<id>}}` references in the concept's
+          inline `{{cite:id}}` references in the concept's
           text. The id is local to the concept; it must be
           unique within the concept's sources list (across
           concept-level, localization-level, and

--- a/schemas/v3/localized-concept.yaml
+++ b/schemas/v3/localized-concept.yaml
@@ -561,13 +561,13 @@ $defs:
     description: |
       Bibliographic reference for a concept or designation.
       May carry an optional `id` for inline reference via
-      `{{cite:<id>}}` mentions in the concept's text.
+      `{{cite:id}}` mentions in the concept's text.
     properties:
       id:
         type: string
         description: |
           Optional stable identifier for the source, used by
-          inline `{{cite:<id>}}` references in the concept's
+          inline `{{cite:id}}` references in the concept's
           text.
       status:
         $ref: "#/$defs/concept_source_statuses"


### PR DESCRIPTION
## Summary

Fix the inline citation reference syntax across all layers.

**Wrong:**  (angle brackets),  (reversed)
**Correct:**  or 

The rule: **ID always first, render term always last. No exceptions.**

## Files updated (5)

-  — 
-  — 
-  — 
-  — 
-  —  + documents both forms (with/without render term) + example