### PR TITLE
feat: add DatasetRegister and Section to ontology layer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -341,6 +341,81 @@ Annotations use the same `DetailedDefinition` structure as definitions, notes,
 and examples, with `content` and optional per-item `sources`.
 
 
+== Dataset register
+
+Each dataset directory contains a `register.yaml` — the self-describing metadata
+file. It carries identity (URN, ref, year), structure (ordering, hierarchical
+sections), provenance (owner, sourceRepo), and relationships (supersedes other
+datasets). See the full schema in `schemas/v3/register.yaml`.
+
+=== Hierarchical sections
+
+Sections provide structural organization for concepts within a dataset. A
+section may contain child sections, forming a tree:
+
+[source,yaml]
+----
+sections:
+  - id: "1"
+    names: { eng: "General terms" }
+  - id: "3"
+    names: { eng: "Geometric concepts" }
+    children:
+      - id: "3.1"
+        names: { eng: "Points and lines" }
+      - id: "3.2"
+        names: { eng: "Surfaces" }
+        ordering: alphabetical
+----
+
+Concepts reference sections via `domains[]` with `ref_type: section`:
+
+[source,yaml]
+----
+data:
+  domains:
+    - source: urn:iso:std:iso:19107
+      id: "3.1"
+      ref_type: section
+----
+
+When a parent section is selected, all descendant sections' concepts are
+included in the filter. This enables the hierarchical section groups in the
+concept-browser.
+
+=== Ordering methods
+
+A dataset or section declares how its concepts should be ordered:
+
+[cols="1,3",options="header"]
+|===
+|Method |Description
+
+|`systematic`
+|Tree hierarchy, top-down left-to-right. Broader concepts before narrower.
+Uses dot-separated identifiers (e.g. 3.6, 3.6.1) and explicit broader/narrower
+edges.
+
+|`mixed`
+|Pedagogical sequence — fundamental concepts first, then specific. No strict
+tree hierarchy.
+
+|`alphabetical`
+|Sorted by preferred designation. Derived at render time from localized concept
+data.
+|===
+
+Ordering can be set at the dataset level (`ordering`) or overridden per-section
+(`section.ordering`).
+
+=== Dataset identity and resolution
+
+The dataset's `urn` is the primary identifier for cross-dataset resolution. When
+a concept in one dataset references a concept in another, the target is
+identified by URN + concept ID. The `urnAliases` field provides additional URN
+patterns for matching.
+
+
 == UML Models
 
 === Concept

--- a/ontologies/README.md
+++ b/ontologies/README.md
@@ -38,7 +38,9 @@ ontologies/
 │   ├── grammar-gender.ttl        # Grammatical gender
 │   ├── grammar-number.ttl        # Grammatical number (5 values: singular/dual/plural/mass/other_number)
 │   ├── register.ttl              # TBX-Linguist register (7 values)
-│   └── part-of-speech.ttl        # Part of speech (6 values)
+│   ├── part-of-speech.ttl        # Part of speech (6 values)
+│   ├── ordering-method.ttl       # Ordering methods (systematic/mixed/alphabetical)
+│   └── concept-reference-type.ttl # Reference types (domain/section/local/designation)
 └── shapes/
     └── glossarist.shacl.ttl      # SHACL validation shapes
 ```

--- a/ontologies/glossarist.context.jsonld
+++ b/ontologies/glossarist.context.jsonld
@@ -39,6 +39,8 @@
     "NonVerbalRepresentation": "gloss:NonVerbalRepresentation",
     "CustomLocality":      "gloss:CustomLocality",
     "Locality":            "gloss:Locality",
+    "DatasetRegister":     "gloss:DatasetRegister",
+    "Section":             "gloss:Section",
 
     "identifier":          { "@id": "gloss:identifier",    "@type": "xsd:string" },
     "uri":                 { "@id": "gloss:uri",           "@type": "xsd:anyURI" },
@@ -213,6 +215,29 @@
 
     "type":                { "@id": "@type", "@container": "@set" },
     "id":                  "@id",
-    "value":               "rdf:value"
+    "value":               "rdf:value",
+
+    "datasetId":           { "@id": "gloss:datasetId",        "@type": "xsd:string" },
+    "datasetRef":          { "@id": "gloss:datasetRef",       "@type": "xsd:string" },
+    "datasetYear":         { "@id": "gloss:datasetYear",      "@type": "xsd:integer" },
+    "datasetUrn":          { "@id": "gloss:datasetUrn",       "@type": "xsd:anyURI" },
+    "datasetUrnAlias":     { "@id": "gloss:datasetUrnAlias",  "@type": "xsd:anyURI" },
+    "datasetRefAlias":     { "@id": "gloss:datasetRefAlias",  "@type": "xsd:string" },
+    "datasetStatus":       { "@id": "gloss:datasetStatus",    "@type": "xsd:string" },
+    "supersedesDataset":   { "@id": "gloss:supersedesDataset","@type": "xsd:string" },
+    "owner":               { "@id": "gloss:owner",            "@type": "xsd:string" },
+    "sourceRepo":          { "@id": "gloss:sourceRepo",       "@type": "xsd:anyURI" },
+    "datasetLanguage":     { "@id": "gloss:datasetLanguage",  "@type": "xsd:string" },
+    "languageOrder":       { "@id": "gloss:languageOrder",    "@type": "xsd:string" },
+    "hasSection":          { "@id": "gloss:hasSection",       "@type": "@id" },
+    "hasDefaultOrdering":  { "@id": "gloss:hasDefaultOrdering", "@type": "@id" },
+    "datasetDescription":  { "@id": "gloss:datasetDescription", "@type": "xsd:string" },
+    "aboutPath":           { "@id": "gloss:aboutPath",        "@type": "xsd:string" },
+    "logo":                { "@id": "gloss:logo",             "@type": "xsd:anyURI" },
+
+    "sectionId":           { "@id": "gloss:sectionId",        "@type": "xsd:string" },
+    "sectionName":         { "@id": "gloss:sectionName",      "@type": "xsd:string" },
+    "hasChildSection":     { "@id": "gloss:hasChildSection",  "@type": "@id" },
+    "sectionOrdering":     { "@id": "gloss:sectionOrdering",  "@type": "@id" }
   }
 }

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -248,6 +248,24 @@ gloss:Locality a owl:Class ;
   rdfs:label "Locality"@en ;
   rdfs:comment "A locality within a cited document (section, clause, page, etc.)."@en .
 
+# ── Dataset Register Layer ────────────────────────────────────────────────
+
+gloss:DatasetRegister a owl:Class ;
+  rdfs:label "Dataset Register"@en ;
+  rdfs:comment """
+    Self-describing dataset metadata (register.yaml). Each dataset directory
+    contains a register.yaml that carries identity, structure, and relationship
+    metadata. Corresponds to DatasetRegister in the Lutaml model.
+  """@en .
+
+gloss:Section a owl:Class ;
+  rdfs:label "Section"@en ;
+  rdfs:comment """
+    A structural division within a dataset. Sections can be hierarchical:
+    a section may contain child sections (e.g. Part > Section > Subsection)
+    via gloss:hasChildSection.
+  """@en .
+
 # ══════════════════════════════════════════════════════════════════════════
 # OBJECT PROPERTIES — Concept-level
 # ══════════════════════════════════════════════════════════════════════════
@@ -1036,3 +1054,137 @@ gloss:shortFormFor a owl:ObjectProperty ;
   rdfs:range gloss:Designation ;
   rdfs:label "short form for"@en ;
   rdfs:comment "This designation is a short form of the target designation."@en .
+
+# ══════════════════════════════════════════════════════════════════════════
+# DATAPROPERTIES — Dataset Register
+# ══════════════════════════════════════════════════════════════════════════
+
+gloss:datasetId a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "dataset id"@en ;
+  rdfs:comment "Dataset identifier, unique within the deployment."@en .
+
+gloss:datasetRef a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "dataset ref"@en ;
+  rdfs:comment "Publication reference string (e.g. OIML V 1:2022)."@en .
+
+gloss:datasetYear a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:integer ;
+  rdfs:label "dataset year"@en ;
+  rdfs:comment "Publication year."@en .
+
+gloss:datasetUrn a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:anyURI ;
+  rdfs:label "dataset URN"@en ;
+  rdfs:comment "Primary URN for the dataset."@en .
+
+gloss:datasetUrnAlias a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:anyURI ;
+  rdfs:label "dataset URN alias"@en ;
+  rdfs:comment "Additional URN patterns for resolution."@en .
+
+gloss:datasetRefAlias a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "dataset ref alias"@en ;
+  rdfs:comment "Alternative publication references."@en .
+
+gloss:datasetStatus a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "dataset status"@en ;
+  rdfs:comment "Dataset lifecycle status: current, superseded, or retired."@en .
+
+gloss:supersedesDataset a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "supersedes dataset"@en ;
+  rdfs:comment "ID of the dataset edition that this one supersedes."@en .
+
+gloss:owner a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "owner"@en ;
+  rdfs:comment "Owning organization (e.g. ISO, IEC, OIML)."@en .
+
+gloss:sourceRepo a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:anyURI ;
+  rdfs:label "source repository"@en ;
+  rdfs:comment "URL of the source repository."@en .
+
+gloss:datasetLanguage a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "dataset language"@en ;
+  rdfs:comment "ISO 639-2 language code available in this dataset."@en .
+
+gloss:languageOrder a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "language order"@en ;
+  rdfs:comment "Preferred display order for languages."@en .
+
+gloss:hasSection a owl:ObjectProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range gloss:Section ;
+  rdfs:label "has section"@en ;
+  rdfs:comment "Top-level section in the dataset's hierarchical section tree."@en .
+
+gloss:hasDefaultOrdering a owl:ObjectProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range skos:Concept ;
+  rdfs:label "default ordering"@en ;
+  rdfs:comment "Default concept ordering method for the dataset."@en .
+
+gloss:datasetDescription a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "dataset description"@en ;
+  rdfs:comment "Localized dataset description."@en .
+
+gloss:aboutPath a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:string ;
+  rdfs:label "about path"@en ;
+  rdfs:comment "Localized path to about-page document."@en .
+
+gloss:logo a owl:DatatypeProperty ;
+  rdfs:domain gloss:DatasetRegister ;
+  rdfs:range xsd:anyURI ;
+  rdfs:label "logo"@en ;
+  rdfs:comment "Relative path to the dataset logo image."@en .
+
+# ══════════════════════════════════════════════════════════════════════════
+# DATAPROPERTIES — Section
+# ══════════════════════════════════════════════════════════════════════════
+
+gloss:sectionId a owl:DatatypeProperty ;
+  rdfs:domain gloss:Section ;
+  rdfs:range xsd:string ;
+  rdfs:label "section id"@en ;
+  rdfs:comment "Section identifier used in concept references and URL routing."@en .
+
+gloss:sectionName a owl:DatatypeProperty ;
+  rdfs:domain gloss:Section ;
+  rdfs:range xsd:string ;
+  rdfs:label "section name"@en ;
+  rdfs:comment "Localized section title."@en .
+
+gloss:hasChildSection a owl:ObjectProperty ;
+  rdfs:domain gloss:Section ;
+  rdfs:range gloss:Section ;
+  rdfs:label "has child section"@en ;
+  rdfs:comment "Hierarchical containment — parent section contains child sections."@en .
+
+gloss:sectionOrdering a owl:ObjectProperty ;
+  rdfs:domain gloss:Section ;
+  rdfs:range skos:Concept ;
+  rdfs:label "section ordering"@en ;
+  rdfs:comment "Per-section ordering override; if absent, inherits dataset default."@en .

--- a/ontologies/shapes/glossarist.shacl.ttl
+++ b/ontologies/shapes/glossarist.shacl.ttl
@@ -606,3 +606,95 @@ gloss:GrammarInfoShape a sh:NodeShape ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
   ] .
+
+# ══════════════════════════════════════════════════════════════════════════
+# Dataset Register shapes
+# ══════════════════════════════════════════════════════════════════════════
+
+gloss:DatasetRegisterShape a sh:NodeShape ;
+  sh:targetClass gloss:DatasetRegister ;
+  sh:property [
+    sh:path gloss:datasetId ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:datasetUrn ;
+    sh:datatype xsd:anyURI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:datasetRef ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:datasetYear ;
+    sh:datatype xsd:integer ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:datasetStatus ;
+    sh:datatype xsd:string ;
+    sh:in ( "current" "superseded" "retired" ) ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:supersedesDataset ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:owner ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:sourceRepo ;
+    sh:datatype xsd:anyURI ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:datasetLanguage ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path gloss:hasSection ;
+    sh:class gloss:Section ;
+  ] ;
+  sh:property [
+    sh:path gloss:hasDefaultOrdering ;
+    sh:class skos:Concept ;
+    sh:valuesFrom <https://www.glossarist.org/ontologies/orderingmethod> ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:logo ;
+    sh:datatype xsd:anyURI ;
+    sh:maxCount 1 ;
+  ] .
+
+gloss:SectionShape a sh:NodeShape ;
+  sh:targetClass gloss:Section ;
+  sh:property [
+    sh:path gloss:sectionId ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:sectionName ;
+    sh:datatype xsd:string ;
+  ] ;
+  sh:property [
+    sh:path gloss:hasChildSection ;
+    sh:class gloss:Section ;
+  ] ;
+  sh:property [
+    sh:path gloss:sectionOrdering ;
+    sh:class skos:Concept ;
+    sh:valuesFrom <https://www.glossarist.org/ontologies/orderingmethod> ;
+    sh:maxCount 1 ;
+  ] .

--- a/ontologies/taxonomies/concept-reference-type.ttl
+++ b/ontologies/taxonomies/concept-reference-type.ttl
@@ -1,0 +1,36 @@
+# Concept Reference Type Taxonomy
+#
+# SKOS ConceptScheme for the ref_type field on domains[] and references[].
+# Distinguishes thematic domains from structural sections and local references.
+# Source: Glossarist ConceptReferenceType
+
+@prefix gloss:   <https://www.glossarist.org/ontologies/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+gloss:conceptreferencetype a skos:ConceptScheme ;
+  skos:prefLabel "Concept Reference Type"@en ;
+  skos:definition "The type of reference from a concept to another concept or structural group, distinguishing thematic from structural classification."@en ;
+  dcterms:source <https://www.glossarist.org/schemas/v3/concept> .
+
+<https://www.glossarist.org/ontologies/conceptreferencetype/domain> a skos:Concept ;
+  skos:inScheme gloss:conceptreferencetype ;
+  skos:prefLabel "domain"@en ;
+  skos:definition "A thematic or subject-area classification. The referenced concept represents a terminological domain (e.g. mathematics, physics)."@en .
+
+<https://www.glossarist.org/ontologies/conceptreferencetype/section> a skos:Concept ;
+  skos:inScheme gloss:conceptreferencetype ;
+  skos:prefLabel "section"@en ;
+  skos:definition "A structural section membership within the dataset's organizational hierarchy (defined in register.yaml)."@en .
+
+<https://www.glossarist.org/ontologies/conceptreferencetype/local> a skos:Concept ;
+  skos:inScheme gloss:conceptreferencetype ;
+  skos:prefLabel "local"@en ;
+  skos:definition "An internal reference within the same glossary, without an external source URN."@en .
+
+<https://www.glossarist.org/ontologies/conceptreferencetype/designation> a skos:Concept ;
+  skos:inScheme gloss:conceptreferencetype ;
+  skos:prefLabel "designation"@en ;
+  skos:definition "A reference to a specific designation within the same concept entry."@en .
+
+gloss:conceptreferencetype skos:hasTopConcept <https://www.glossarist.org/ontologies/conceptreferencetype/domain> , <https://www.glossarist.org/ontologies/conceptreferencetype/section> , <https://www.glossarist.org/ontologies/conceptreferencetype/local> , <https://www.glossarist.org/ontologies/conceptreferencetype/designation> .

--- a/ontologies/taxonomies/ordering-method.ttl
+++ b/ontologies/taxonomies/ordering-method.ttl
@@ -1,0 +1,30 @@
+# Ordering Method Taxonomy
+#
+# SKOS ConceptScheme for concept ordering methods within a dataset or section.
+# Source: ISO 10241-1, Glossarist register.yaml
+
+@prefix gloss:   <https://www.glossarist.org/ontologies/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+gloss:orderingmethod a skos:ConceptScheme ;
+  skos:prefLabel "Ordering Method"@en ;
+  skos:definition "How concepts are ordered within a dataset or section (ISO 10241-1)."@en ;
+  dcterms:source <https://www.glossarist.org/schemas/v3/register> .
+
+<https://www.glossarist.org/ontologies/orderingmethod/systematic> a skos:Concept ;
+  skos:inScheme gloss:orderingmethod ;
+  skos:prefLabel "systematic"@en ;
+  skos:definition "Tree hierarchy, top-down left-to-right. Broader concepts before narrower. Uses dot-separated identifiers and explicit broader/narrower edges."@en .
+
+<https://www.glossarist.org/ontologies/orderingmethod/mixed> a skos:Concept ;
+  skos:inScheme gloss:orderingmethod ;
+  skos:prefLabel "mixed"@en ;
+  skos:definition "Pedagogical sequence — fundamental concepts first, then specific. No strict tree hierarchy."@en .
+
+<https://www.glossarist.org/ontologies/orderingmethod/alphabetical> a skos:Concept ;
+  skos:inScheme gloss:orderingmethod ;
+  skos:prefLabel "alphabetical"@en ;
+  skos:definition "Sorted by preferred designation. Derived at render time from localized concept data."@en .
+
+gloss:orderingmethod skos:hasTopConcept <https://www.glossarist.org/ontologies/orderingmethod/systematic> , <https://www.glossarist.org/ontologies/orderingmethod/mixed> , <https://www.glossarist.org/ontologies/orderingmethod/alphabetical> .

--- a/schemas/v3/examples/18-hierarchical-sections-concept.yaml
+++ b/schemas/v3/examples/18-hierarchical-sections-concept.yaml
@@ -1,0 +1,18 @@
+# 18 — Concept referencing a hierarchical section
+#
+# Demonstrates a concept that belongs to section "3.1" via domains[].
+# The concept-browser resolves the parent chain (3 → 3.1) so that
+# selecting section "3" also includes this concept.
+---
+id: ex-3.1.1
+data:
+  identifier: "3.1.1"
+  domains:
+    - source: "urn:example:std:ex:1000:2026"
+      id: "3.1"
+      ref_type: section
+  tags: [geometry, points]
+  localized_concepts:
+    eng: ex-3.1.1-eng
+status: valid
+date_accepted: "2026-01-01T00:00:00+00:00"

--- a/schemas/v3/examples/18-hierarchical-sections-register.yaml
+++ b/schemas/v3/examples/18-hierarchical-sections-register.yaml
@@ -1,0 +1,39 @@
+# 18 — Hierarchical Sections Register
+#
+# Demonstrates register.yaml with hierarchical sections:
+# - Top-level sections (1, 3)
+# - Nested children (3 → 3.1, 3.2)
+# - Per-section ordering override (3.2 uses alphabetical)
+# - Dataset-level default ordering (systematic)
+---
+schema_type: glossarist
+schema_version: "3"
+id: example-glossary
+ref: "EX 1000:2026"
+year: 2026
+urn: "urn:example:std:ex:1000:2026"
+status: current
+owner: EXAMPLE
+languages: [eng, fra]
+languageOrder: [eng, fra]
+ordering: systematic
+sections:
+  - id: "1"
+    names:
+      eng: "General terms"
+      fra: "Termes généraux"
+  - id: "3"
+    names:
+      eng: "Geometric concepts"
+      fra: "Concepts géométriques"
+    ordering: systematic
+    children:
+      - id: "3.1"
+        names:
+          eng: "Points and lines"
+          fra: "Points et lignes"
+      - id: "3.2"
+        names:
+          eng: "Surfaces"
+          fra: "Surfaces"
+        ordering: alphabetical

--- a/schemas/v3/examples/README.md
+++ b/schemas/v3/examples/README.md
@@ -29,6 +29,7 @@ localizations.
 | 15 | Citation & locality features | — | `15-citation-features.yaml` |
 | 16 | Tags (organizational metadata) | `16-tags.yaml` | — |
 | 17 | Dataset register (URN resolution) | `17-register-dataset.yaml` | — |
+| 18 | Hierarchical sections | `18-hierarchical-sections-concept.yaml` | — (companion: `18-hierarchical-sections-register.yaml`) |
 
 ---
 


### PR DESCRIPTION
## Summary

The concept-browser now supports hierarchical section groups (commit 3f96c10). The data model ( recursion) already existed in Lutaml + YAML, but was completely absent from the formal ontology layer — violating single-source-of-truth.

This PR brings , , , and  into all six representation layers.

## Changes (10 files, 472 insertions)

### Ontology (`glossarist.ttl`) — +152 lines
- `gloss:DatasetRegister` class + 15 properties
- `gloss:Section` class + 4 properties (incl. `hasChildSection` for hierarchy)

### SHACL shapes (`glossarist.shacl.ttl`) — +92 lines
- `DatasetRegisterShape` — validates id, urn, status, sections, ordering
- `SectionShape` — validates sectionId, children, ordering override

### JSON-LD context (`glossarist.context.jsonld`) — +27 lines
- `DatasetRegister`, `Section` class terms
- 19 new property terms

### New SKOS taxonomies
- `ordering-method.ttl` — systematic, mixed, alphabetical
- `concept-reference-type.ttl` — domain, section, local, designation

### New examples
- `18-hierarchical-sections-register.yaml` — hierarchical section tree
- `18-hierarchical-sections-concept.yaml` — concept referencing section 3.1

### Documentation
- README: new sections for Dataset register, Hierarchical sections, Ordering methods
- ontologies/README.md: lists new taxonomies
- examples/README.md: row 18 added

## Design principles
- **MECE**: Section (structural) vs Reference type domain (thematic) are separate concerns
- **OCP**: New classes/properties added, no existing ones modified
- **SSOT**: All six layers now express hierarchical sections consistently
- **DRY**: Ordering method reused between DatasetRegister and Section via shared taxonomy