### PR TITLE
feat: transitive section hierarchy + parent inverse

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -383,6 +383,28 @@ When a parent section is selected, all descendant sections' concepts are
 included in the filter. This enables the hierarchical section groups in the
 concept-browser.
 
+==== Cascading membership semantics
+
+Section membership is **transitive**: if section `3` contains section `3.1`,
+which contains section `3.1.1`, then a concept in section `3.1.1` is also a
+member of `3.1` and `3` for the purposes of filtering and display. In the
+ontology, `gloss:hasChildSection` and its inverse `gloss:hasParentSection` are
+declared `owl:TransitiveProperty` so this closure holds at any depth.
+
+==== Term-ID-prefix derivation convention
+
+When a concept has no explicit `domains[]` entry with `ref_type: section`,
+consumers MAY derive section membership from the concept's identifier using a
+dot- or dash-prefix convention:
+
+* `103-01-01` → section `103`
+* `3.1.1` → section `3`
+* `103-01` → section `103`
+
+The longest registered section prefix wins. This convention is a fallback for
+legacy datasets and is NOT authoritative — explicit `domains[]` entries always
+take precedence.
+
 === Ordering methods
 
 A dataset or section declares how its concepts should be ordered:

--- a/ontologies/glossarist.context.jsonld
+++ b/ontologies/glossarist.context.jsonld
@@ -238,6 +238,7 @@
     "sectionId":           { "@id": "gloss:sectionId",        "@type": "xsd:string" },
     "sectionName":         { "@id": "gloss:sectionName",      "@type": "xsd:string" },
     "hasChildSection":     { "@id": "gloss:hasChildSection",  "@type": "@id" },
+    "hasParentSection":    { "@id": "gloss:hasParentSection", "@type": "@id" },
     "sectionOrdering":     { "@id": "gloss:sectionOrdering",  "@type": "@id" }
   }
 }

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -1177,11 +1177,26 @@ gloss:sectionName a owl:DatatypeProperty ;
   rdfs:label "section name"@en ;
   rdfs:comment "Localized section title."@en .
 
-gloss:hasChildSection a owl:ObjectProperty ;
+gloss:hasChildSection a owl:TransitiveProperty ;
+  owl:inverseOf gloss:hasParentSection ;
   rdfs:domain gloss:Section ;
   rdfs:range gloss:Section ;
   rdfs:label "has child section"@en ;
-  rdfs:comment "Hierarchical containment — parent section contains child sections."@en .
+  rdfs:comment """
+    Hierarchical containment — parent section contains child sections.
+    Transitive: selecting a parent section includes all descendants.
+    This enables cascading membership at any depth (Part > Section > Subsection).
+  """@en .
+
+gloss:hasParentSection a owl:TransitiveProperty ;
+  owl:inverseOf gloss:hasChildSection ;
+  rdfs:domain gloss:Section ;
+  rdfs:range gloss:Section ;
+  rdfs:label "has parent section"@en ;
+  rdfs:comment """
+    Inverse of hasChildSection. Transitive: a section inherits membership
+    from all its ancestors. Used for upward traversal in SPARQL queries.
+  """@en .
 
 gloss:sectionOrdering a owl:ObjectProperty ;
   rdfs:domain gloss:Section ;


### PR DESCRIPTION
Aligns the ontology with how the concept-browser uses hierarchical sections at any depth.

## Changes

### Ontology (`glossarist.ttl`)
- `gloss:hasChildSection` is now `owl:TransitiveProperty`
- New `gloss:hasParentSection` as transitive inverse

This means selecting section `3` (containing `3.1` containing `3.1.1`) formally entails all descendant sections at any depth.

### JSON-LD context
- Added `hasParentSection` term

### README
- New `Cascading membership semantics` subsection documents the transitive closure
- New `Term-ID-prefix derivation convention` subsection documents the fallback heuristic used by consumers when no explicit `domains[]` entry exists (e.g. `103-01-01` → section `103`)

## Why
The concept-browser's `buildSectionParentMap` only handles direct parent-child edges. With transitivity declared in the ontology, RDF/SPARQL consumers get the full closure automatically, and the YAML schema semantics are formally defined.