### PR TITLE
feat: NonVerbalEntity models — Figure, Table, Formula as dataset-level entities

### DIFF
--- a/models/concepts/Figure.lutaml
+++ b/models/concepts/Figure.lutaml
@@ -1,0 +1,25 @@
+class Figure extends NonVerbalEntity {
+  definition {
+    A dataset-level figure entity (ISO 10241-1 §6.5 non-verbal representation).
+    Authored once at datasets/{ds}/figures/{fig-id}.yaml and referenced by
+    any number of concepts via stable ID.
+
+    A Figure may carry multiple image variants (SVG + PNG + dark/light) for
+    responsive rendering and accessibility. Composite figures use recursive
+    subfigures.
+  }
+
+  +images: FigureImage [1..*] {
+    definition {
+      Image variants. At least one required. Multiple enable responsive
+      <picture> with format/role-based selection.
+    }
+  }
+
+  +subfigures: Figure [0..*] {
+    definition {
+      Child figures forming a recursive composite. For example,
+      a "dispersion prism" figure with "input" and "output" subfigures.
+    }
+  }
+}

--- a/models/concepts/FigureImage.lutaml
+++ b/models/concepts/FigureImage.lutaml
@@ -1,0 +1,45 @@
+class FigureImage {
+  definition {
+    One image variant within a Figure. Multiple variants enable
+    responsive images, format fallbacks, and accessibility
+    (dark/light, language-specific, print-optimized).
+  }
+
+  +src: String [1] {
+    definition {
+      Filename in the dataset's images/ directory.
+      No path traversal (../ forbidden at build).
+    }
+  }
+
+  +format: String [1] {
+    definition {
+      Image format: svg, png, jpg, webp, avif, gif.
+    }
+  }
+
+  +role: String [0..1] {
+    definition {
+      Variant role: vector, raster, dark, light, print.
+      Drives consumer-side <picture> element ordering.
+    }
+  }
+
+  +width: Integer [0..1] {
+    definition {
+      Intrinsic width in pixels. Required for raster to prevent layout shift.
+    }
+  }
+
+  +height: Integer [0..1] {
+    definition {
+      Intrinsic height in pixels. Required for raster to prevent layout shift.
+    }
+  }
+
+  +scale: Integer [0..1] {
+    definition {
+      Resolution multiplier (e.g. 2 for retina displays). Used in srcset.
+    }
+  }
+}

--- a/models/concepts/Formula.lutaml
+++ b/models/concepts/Formula.lutaml
@@ -1,0 +1,20 @@
+class Formula extends NonVerbalEntity {
+  definition {
+    A dataset-level formula entity (ISO 10241-1 §6.5 non-verbal representation).
+    Authored at datasets/{ds}/formulas/{formula-id}.yaml and shared across
+    concepts. The mathematical expression is stored in a notation format.
+  }
+
+  +expression: LocalizedStringMap [0..1] {
+    definition {
+      The mathematical expression, localized. Different languages may use
+      different notation conventions.
+    }
+  }
+
+  +notation: String [0..1] {
+    definition {
+      Expression notation: latex, mathml, asciimath.
+    }
+  }
+}

--- a/models/concepts/NonVerbalEntity.lutaml
+++ b/models/concepts/NonVerbalEntity.lutaml
@@ -1,0 +1,48 @@
+class NonVerbalEntity {
+  definition {
+    Abstract base for dataset-level non-verbal representation entities
+    (ISO 10241-1 §6.5). Figures, Tables, and Formulas inherit common
+    metadata: stable identity, localized caption/description (accessibility),
+    and provenance sources. Each is authored once at the dataset level and
+    referenced by any number of concepts.
+  }
+
+  +id: String [1] {
+    definition {
+      Stable identifier, dataset-unique. Used in inline mentions
+      ({{fig:id}}, {{table:id}}, {{formula:id}}) and structural
+      references (figures: [], tables: [], formulas: []).
+    }
+  }
+
+  +identifier: String [0..1] {
+    definition {
+      Display form ("Figure 7c", "Table 2", "Equation 1").
+      Optional; consumers may auto-derive.
+    }
+  }
+
+  +caption: LocalizedStringMap [0..1] {
+    definition {
+      Localized title/caption, keyed by ISO 639-2 language code.
+    }
+  }
+
+  +description: LocalizedStringMap [0..1] {
+    definition {
+      Localized long description for accessibility (aria-describedby).
+    }
+  }
+
+  +alt: LocalizedStringMap [0..1] {
+    definition {
+      Localized short alt text for screen readers.
+    }
+  }
+
+  +sources: ConceptSource [0..*] {
+    definition {
+      Bibliographic sources (provenance), parallel to concept sources.
+    }
+  }
+}

--- a/models/concepts/Table.lutaml
+++ b/models/concepts/Table.lutaml
@@ -1,0 +1,21 @@
+class Table extends NonVerbalEntity {
+  definition {
+    A dataset-level table entity (ISO 10241-1 §6.5 non-verbal representation).
+    Authored at datasets/{ds}/tables/{table-id}.yaml and shared across
+    concepts. Content is stored as structured data or markup.
+  }
+
+  +content: LocalizedStringMap [0..1] {
+    definition {
+      Table content. For structured format: { headers: [...], rows: [...] }.
+      For markup format: the markup string keyed by language.
+    }
+  }
+
+  +format: String [0..1] {
+    definition {
+      Content format: structured, html, markdown, asciidoc.
+      Defaults to structured if absent.
+    }
+  }
+}

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -1203,3 +1203,84 @@ gloss:sectionOrdering a owl:ObjectProperty ;
   rdfs:range skos:Concept ;
   rdfs:label "section ordering"@en ;
   rdfs:comment "Per-section ordering override; if absent, inherits dataset default."@en .
+
+# ── Non-Verbal Entities (ISO 10241-1 §6.5) ──────────────────────────────
+
+gloss:NonVerbalEntity a owl:Class ;
+  rdfs:label "Non-Verbal Entity"@en ;
+  rdfs:comment """
+    Abstract base for dataset-level non-verbal representation entities
+    (ISO 10241-1 §6.5). Figures, Tables, and Formulas inherit common
+    metadata: id, identifier, caption, description, alt, sources.
+    Authored once and shared across concepts.
+  """@en .
+
+gloss:Figure a owl:Class ;
+  rdfs:subClassOf gloss:NonVerbalEntity ;
+  rdfs:label "Figure"@en ;
+  rdfs:comment """
+    A dataset-level figure entity with localized caption/alt and
+    multiple image variants. May contain recursive subfigures.
+  """@en .
+
+gloss:Table a owl:Class ;
+  rdfs:subClassOf gloss:NonVerbalEntity ;
+  rdfs:label "Table"@en ;
+  rdfs:comment "A dataset-level table entity with localized content."@en .
+
+gloss:Formula a owl:Class ;
+  rdfs:subClassOf gloss:NonVerbalEntity ;
+  rdfs:label "Formula"@en ;
+  rdfs:comment "A dataset-level formula entity with localized expression."@en .
+
+gloss:FigureImage a owl:Class ;
+  rdfs:label "Figure Image"@en ;
+  rdfs:comment "One image variant within a Figure (format, role, dimensions)."@en .
+
+gloss:caption a owl:DatatypeProperty ;
+  rdfs:domain gloss:NonVerbalEntity ;
+  rdfs:range rdf:langString ;
+  rdfs:label "caption"@en ;
+  rdfs:comment "Localized title/caption."@en .
+
+gloss:altText a owl:DatatypeProperty ;
+  rdfs:domain gloss:NonVerbalEntity ;
+  rdfs:range rdf:langString ;
+  rdfs:label "alt text"@en ;
+  rdfs:comment "Localized short alt text for screen readers."@en .
+
+gloss:description a owl:DatatypeProperty ;
+  rdfs:domain gloss:NonVerbalEntity ;
+  rdfs:range rdf:langString ;
+  rdfs:label "description"@en ;
+  rdfs:comment "Localized long description (aria-describedby)."@en .
+
+gloss:image a owl:ObjectProperty ;
+  rdfs:domain gloss:Figure ;
+  rdfs:range gloss:FigureImage ;
+  rdfs:label "image"@en ;
+  rdfs:comment "An image variant of a Figure."@en .
+
+gloss:hasSubfigure a owl:ObjectProperty ;
+  rdfs:domain gloss:Figure ;
+  rdfs:range gloss:Figure ;
+  rdfs:label "has subfigure"@en ;
+  rdfs:comment "Recursive composite subfigure."@en .
+
+gloss:src a owl:DatatypeProperty ;
+  rdfs:domain gloss:FigureImage ;
+  rdfs:range xsd:string ;
+  rdfs:label "src"@en ;
+  rdfs:comment "Image filename relative to images/ directory."@en .
+
+gloss:format a owl:DatatypeProperty ;
+  rdfs:domain gloss:FigureImage ;
+  rdfs:range xsd:string ;
+  rdfs:label "format"@en ;
+  rdfs:comment "Image format (svg, png, jpg, webp, avif, gif)."@en .
+
+gloss:role a owl:DatatypeProperty ;
+  rdfs:domain gloss:FigureImage ;
+  rdfs:range xsd:string ;
+  rdfs:label "role"@en ;
+  rdfs:comment "Variant role (vector, raster, dark, light, print)."@en .

--- a/schemas/v3/examples/16-typed-notes.yaml
+++ b/schemas/v3/examples/16-typed-notes.yaml
@@ -1,0 +1,29 @@
+# 16 — Typed Notes (Note vs Annotation)
+#
+# Notes can be classified by semantic role. Regular "notes" provide
+# supplementary information about the concept. "Annotations" are
+# editorial commentary about the definition itself (how to interpret it,
+# term substitutions, corrections). The "type" field defaults to "note"
+# when absent.
+---
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567891
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: reference measurement procedure
+    normative_status: preferred
+  definition:
+  - content: >-
+      measurement procedure accepted as providing measurement results
+      fit for their intended use in assessing measurement trueness
+  notes:
+  - type: annotation
+    content: >-
+      The definition systematically uses preferred terms and so is long
+      and complex. A shorter definition might be sufficient.
+  - content: >-
+      Reference measurement procedures are often used in calibration
+      and in assigning values to reference materials.
+  examples: []
+status: valid

--- a/schemas/v3/examples/19-non-verbal-entities.yaml
+++ b/schemas/v3/examples/19-non-verbal-entities.yaml
@@ -1,0 +1,91 @@
+# 19 — Non-Verbal Entities (Figure, Table, Formula)
+#
+# Demonstrates dataset-level non-verbal representation entities.
+# Each entity is authored once and referenced by concepts via stable ID.
+
+# --- Figure with multiple variants + localized caption/alt ---
+id: mixed-reflection
+identifier: "Figure 7c"
+caption:
+  eng: "Mixed reflection geometry"
+  fra: "Géométrie de réflexion mixte"
+alt:
+  eng: "Diagram showing simultaneous specular and diffuse reflection from a surface."
+  fra: "Diagramme montrant la réflexion simultanée spéculaire et diffuse."
+description:
+  eng: "An incident ray hits a surface at angle θ. Two reflected rays leave: one at θ (specular) and several scattered (diffuse)."
+images:
+  - src: mixed-reflection.svg
+    format: svg
+    role: vector
+  - src: mixed-reflection.png
+    format: png
+    role: raster
+    width: 1600
+    height: 1200
+sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: CIE
+        id: "17-21-035"
+    modification: "Adapted with translated labels."
+subfigures: []
+
+# --- Composite figure with subfigures ---
+---
+id: dispersion-prism
+identifier: "Figure 3"
+caption:
+  eng: "Dispersion by a prism"
+subfigures:
+  - id: dispersion-prism-input
+    identifier: "Figure 3a"
+    caption: { eng: "Input beam" }
+    alt: { eng: "White light beam entering a prism." }
+    images:
+      - src: dispersion-input.svg
+        format: svg
+        role: vector
+  - id: dispersion-prism-output
+    identifier: "Figure 3b"
+    caption: { eng: "Output spectrum" }
+    alt: { eng: "Spectrum of colors exiting the prism." }
+    images:
+      - src: dispersion-output.svg
+        format: svg
+        role: vector
+
+# --- Table entity ---
+---
+id: si-base-units
+identifier: "Table 1"
+caption:
+  eng: "SI base units"
+alt:
+  eng: "Seven SI base units with names, symbols, and dimensions."
+content:
+  headers: [Quantity, Name, Symbol, Dimension]
+  rows:
+    - [length, metre, m, L]
+    - [mass, kilogram, kg, M]
+    - [time, second, s, T]
+    - [electric current, ampere, A, I]
+    - [temperature, kelvin, K, Θ]
+    - [amount, mole, mol, N]
+    - [luminous intensity, candela, cd, J]
+format: structured
+
+# --- Formula entity ---
+---
+id: wave-equation
+identifier: "Equation 1"
+caption:
+  eng: "Electromagnetic wave equation"
+alt:
+  eng: "Second-order partial differential equation for the electric field."
+description:
+  eng: "Describes wave propagation in free space."
+expression:
+  eng: "\\nabla^2 \\mathbf{E} = \\mu_0 \\epsilon_0 \\frac{\\partial^2 \\mathbf{E}}{\\partial t^2}"
+notation: latex

--- a/schemas/v3/figure.yaml
+++ b/schemas/v3/figure.yaml
@@ -1,0 +1,92 @@
+# Figure Schema (ISO 10241-1 §6.5 non-verbal representation)
+#
+# Dataset-level figure entities authored at datasets/{ds}/figures/{fig-id}.yaml.
+# Referenced by concepts via figures: [id] or {{fig:id}} mentions.
+
+$schema: "http://json-schema.org/draft-07/schema#"
+title: Figure
+description: A dataset-level figure entity with localized caption/alt and multiple image variants.
+
+type: object
+required:
+  - id
+  - images
+  - alt
+additionalProperties: false
+
+properties:
+  id:
+    type: string
+    description: Stable identifier, dataset-unique. kebab-case recommended.
+
+  identifier:
+    type: string
+    description: Display form (e.g. "Figure 7c"). Optional.
+
+  caption:
+    type: object
+    description: Localized title/caption, keyed by ISO 639-2 language code.
+    additionalProperties:
+      type: string
+
+  description:
+    type: object
+    description: Localized long description (aria-describedby).
+    additionalProperties:
+      type: string
+
+  alt:
+    type: object
+    description: Localized short alt text for screen readers.
+    additionalProperties:
+      type: string
+
+  images:
+    type: array
+    description: Image variants. At least one required.
+    minItems: 1
+    items:
+      type: object
+      required: [src, format]
+      additionalProperties: false
+      properties:
+        src:
+          type: string
+          description: Filename in images/ directory.
+        format:
+          type: string
+          enum: [svg, png, jpg, webp, avif, gif]
+        role:
+          type: string
+          enum: [vector, raster, dark, light, print]
+        width:
+          type: integer
+        height:
+          type: integer
+        scale:
+          type: integer
+
+  sources:
+    type: array
+    description: Bibliographic sources (provenance).
+    items:
+      $ref: "#/$defs/concept_source"
+
+  subfigures:
+    type: array
+    description: Recursive composite subfigures.
+    items:
+      $ref: "#/$defs/figure"
+
+$defs:
+  concept_source:
+    type: object
+    additionalProperties: false
+    properties:
+      id:
+        type: string
+      type:
+        type: string
+        enum: [authoritative, lineage]
+      origin:
+        type: object


### PR DESCRIPTION
ISO 10241-1 §6.5 non-verbal representations as first-class dataset-level entities.

## New Lutaml models
- `NonVerbalEntity`: abstract base (id, identifier, caption, description, alt, sources)
- `Figure extends NonVerbalEntity`: images + recursive subfigures
- `FigureImage`: src, format, role, width, height, scale
- `Table extends NonVerbalEntity`: content + format
- `Formula extends NonVerbalEntity`: expression + notation

## New schemas
- `schemas/v3/figure.yaml`: JSON Schema for Figure entities
- `schemas/v3/examples/19-non-verbal-entities.yaml`: example with figure (multi-variant, subfigures), table, formula

## Ontology additions
- Classes: NonVerbalEntity, Figure, Table, Formula, FigureImage
- Properties: caption, altText, description (rdf:langString); image, hasSubfigure (object); src, format, role (datatype)

## Design
Authored once at `figures/`, `tables/`, `formulas/` directories and shared across concepts via stable ID. Concept-owned inline form (NonVerbRep) coexists with localized caption/description for accessibility.

Authoritative implementation in glossarist-ruby: `lib/glossarist/non_verbal_entity.rb`