### PR TITLE
feat: add Bibliography dataset model (V3 glossarist dataset syntax)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -463,9 +463,82 @@ bibliography:
   reference: ISO 15704
 ----
 
-The same single-key convention applies to every dataset collection file
-(`images.yaml`, and any future equivalent): the collection is an array of typed
-items grouped under one wrapper key.
+The same single-key convention applies to every dataset-wide collection
+file: the collection is an array of typed items grouped under one wrapper
+key. (Per-entity files such as `concepts/{id}.yaml` and `figures/{id}.yaml`
+are single-object mappings, not collection files, and do not use a wrapper
+key.)
+
+
+== Non-verbal entities
+
+Non-verbal representations (ISO 10241-1 §6.5) — images, tables, formulas —
+exist in two coexistence levels, both sharing the same accessibility +
+provenance payload via `NonVerbalEntity`:
+
+`NonVerbRep`::
+The **concept-local inline** form, attached to a concept's `non_verb_rep`
+collection. Has no dataset-wide identity — its position in the collection
+is its identity. Discriminated by `type: image | table | formula`. When
+`type: image`, carries a `images[]` collection of `FigureImage` variants.
+
+`Figure` / `Table` / `Formula`::
+The **dataset-shared** form, authored at `figures/{id}.yaml`,
+`tables/{id}.yaml`, `formulas/{id}.yaml`. Each has a stable `id` (matches
+the filename, used for cross-references) and an optional human-readable
+`identifier` (used for display and AsciiDoc xref targets). Figure carries
+`images[]` (image variants) and recursive `subfigures[]`.
+
+The shared `NonVerbalEntity` payload:
+
+caption:: Localized short title (`LocalizedStringMap`).
+description:: Localized long description (a11y screen readers).
+alt:: Localized alternative text (a11y short label).
+sources:: Bibliographic `ConceptSource` collection.
+
+The dataset-shared variant (`SharedNonVerbalEntity`) adds `id` and
+`identifier`. The two-level hierarchy is the single source of truth for
+"where does this field belong": a11y + provenance live on the base;
+dataset identity lives on the shared variant; content-specific fields
+(`images`, `subfigures`, table cells, formula notation) live on the
+leaves.
+
+`FigureImage` carries one image variant within a Figure or image-type
+NonVerbRep: `src` (URI/path), `format`, `role` (vector/raster/dark/light/
+print), and optional `width`, `height`, `scale`. Multiple variants enable
+responsive rendering and accessibility fallbacks.
+
+[source,yaml]
+----
+# datasets/{ds}/figures/fig_A.23.yaml
+id: fig_A.23
+identifier: A.23
+images:
+- src: images/fig_A.23.png
+  format: png
+  role: raster
+caption:
+  eng: Sensor topology
+alt:
+  eng: Diagram of sensor network topology
+sources:
+- type: authoritative
+  status: identical
+----
+
+A concept-local NonVerbRep on a concept YAML:
+
+[source,yaml]
+----
+non_verb_rep:
+- type: image
+  images:
+  - src: assets/concept-diagram.svg
+    format: svg
+    role: vector
+  alt:
+    eng: Diagram of the concept
+----
 
 
 == UML Models

--- a/README.adoc
+++ b/README.adoc
@@ -438,6 +438,36 @@ identified by URN + concept ID. The `urnAliases` field provides additional URN
 patterns for matching.
 
 
+== Bibliography
+
+A dataset directory may contain a `bibliography.yaml` — the dataset's
+bibliography: an ordered collection of the bibliographic references cited by its
+concepts. It is the *V3 glossarist dataset syntax* for a collection file — a
+YAML mapping with a single key, `bibliography`, whose value is an array of typed
+`BibliographyEntry` items. The collection is grouped under one wrapper key (no
+stray top-level array) and is not keyed by reference string: each entry is a
+typed item carrying its own `id`. See the full schema in
+`schemas/v3/bibliography.yaml`.
+
+[source,yaml]
+----
+bibliography:
+- id: ref_1
+  reference: ISO 704
+  title: Terminology work — Principles and methods
+- id: ref_23
+  reference: UNECE TRANS/WP29/1045
+  title: Common definitions of vehicle categories, masses and dimensions
+  link: https://www.unece.org/fileadmin/DAM/trans/doc/2005/wp29/TRANS-WP29-1045e.pdf
+- id: iso_std_iso_15704_en
+  reference: ISO 15704
+----
+
+The same single-key convention applies to every dataset collection file
+(`images.yaml`, and any future equivalent): the collection is an array of typed
+items grouped under one wrapper key.
+
+
 == UML Models
 
 === Concept

--- a/models/concepts/BibliographyData.lutaml
+++ b/models/concepts/BibliographyData.lutaml
@@ -1,0 +1,20 @@
+class BibliographyData {
+  definition {
+    The bibliography of a dataset, persisted as bibliography.yaml. A YAML
+    mapping with a single key, "bibliography", whose value is an ordered array
+    of BibliographyEntry items — the V3 glossarist dataset syntax for a
+    collection file. Authored once per dataset and referenced by concepts via
+    their sources and inline cite mentions.
+
+    The document root is a mapping, not a stray top-level array, and the
+    collection is not keyed by reference string: each entry is a typed item
+    carrying its own +id+.
+  }
+
+  +bibliography: BibliographyEntry [0..*] {
+    definition {
+      The dataset's bibliographic references, as an ordered array under the
+      single "bibliography" wrapper key.
+    }
+  }
+}

--- a/models/concepts/BibliographyEntry.lutaml
+++ b/models/concepts/BibliographyEntry.lutaml
@@ -1,0 +1,39 @@
+class BibliographyEntry {
+  definition {
+    A single bibliographic reference in a dataset's bibliography
+    (bibliography.yaml). A bibliography is an ordered collection of these
+    entries; each carries its own identifier as the +id+ field, rather than
+    being indexed by an out-of-band hash key.
+  }
+
+  +id: String [1] {
+    definition {
+      Entry identifier, dataset-unique. Cited from concept sources and inline
+      {{cite:...}} mentions.
+    }
+  }
+
+  +reference: String [1] {
+    definition {
+      Publication reference string, e.g. "ISO 704", "IEC 60050".
+    }
+  }
+
+  +title: String [0..1] {
+    definition {
+      Title of the referenced document.
+    }
+  }
+
+  +link: String [0..1] {
+    definition {
+      URL to the referenced document.
+    }
+  }
+
+  +type: String [0..1] {
+    definition {
+      Document type, e.g. "standard".
+    }
+  }
+}

--- a/models/concepts/Figure.lutaml
+++ b/models/concepts/Figure.lutaml
@@ -1,25 +1,23 @@
-class Figure extends NonVerbalEntity {
+class Figure < SharedNonVerbalEntity {
   definition {
-    A dataset-level figure entity (ISO 10241-1 §6.5 non-verbal representation).
-    Authored once at datasets/{ds}/figures/{fig-id}.yaml and referenced by
-    any number of concepts via stable ID.
-
-    A Figure may carry multiple image variants (SVG + PNG + dark/light) for
-    responsive rendering and accessibility. Composite figures use recursive
-    subfigures.
+    A dataset-level figure entity (ISO 10241-1 §6.5 — non-verbal
+    representation). Authored once at datasets/{ds}/figures/{fig-id}.yaml
+    and referenced by any number of concepts via stable id — the same
+    sharing pattern as bibliography entries. A Figure may carry multiple
+    image variants (SVG + PNG + dark/light) for responsive rendering and
+    accessibility. Composite figures use recursive subfigures.
   }
-
-  +images: FigureImage [1..*] {
+  +images: FigureImage [0..*] {
     definition {
-      Image variants. At least one required. Multiple enable responsive
-      <picture> with format/role-based selection.
+      Image variants. The same logical figure may be rendered as SVG for
+      digital, PNG for fallback, dark-mode-tuned, etc.
     }
   }
-
   +subfigures: Figure [0..*] {
     definition {
-      Child figures forming a recursive composite. For example,
-      a "dispersion prism" figure with "input" and "output" subfigures.
+      Optional recursive composite. A figure with subfigures is the union
+      of its own images and its subfigures. Subfigure ids must be unique
+      within the parent figure.
     }
   }
 }

--- a/models/concepts/FigureImage.lutaml
+++ b/models/concepts/FigureImage.lutaml
@@ -1,45 +1,33 @@
 class FigureImage {
   definition {
-    One image variant within a Figure. Multiple variants enable
-    responsive images, format fallbacks, and accessibility
-    (dark/light, language-specific, print-optimized).
+    One image variant within a Figure or NonVerbRep. Multiple variants enable
+    responsive images, format fallbacks, and accessibility (dark/light,
+    language-specific, print). The role field drives consumer-side selection.
   }
-
   +src: String [1] {
     definition {
-      Filename in the dataset's images/ directory.
-      No path traversal (../ forbidden at build).
+      URI reference to the image asset: a relative path within the dataset
+      (e.g. "images/fig_A.23.png"), a URN, or an absolute URL.
     }
   }
-
-  +format: String [1] {
+  +format: String [0..1] {
     definition {
-      Image format: svg, png, jpg, webp, avif, gif.
+      File format hint, e.g. "svg", "png", "jpg". Used together with role to
+      pick an appropriate variant.
     }
   }
-
   +role: String [0..1] {
     definition {
-      Variant role: vector, raster, dark, light, print.
-      Drives consumer-side <picture> element ordering.
+      Selection role. Common values: "vector" (SVG, resolution-independent),
+      "raster" (PNG/JPG, photos), "dark" (dark backgrounds), "light"
+      (light backgrounds), "print" (high-resolution for print output).
     }
   }
-
-  +width: Integer [0..1] {
-    definition {
-      Intrinsic width in pixels. Required for raster to prevent layout shift.
-    }
-  }
-
-  +height: Integer [0..1] {
-    definition {
-      Intrinsic height in pixels. Required for raster to prevent layout shift.
-    }
-  }
-
+  +width: Integer [0..1]
+  +height: Integer [0..1]
   +scale: Integer [0..1] {
     definition {
-      Resolution multiplier (e.g. 2 for retina displays). Used in srcset.
+      Optional scale percentage relative to the asset's native dimensions.
     }
   }
 }

--- a/models/concepts/Formula.lutaml
+++ b/models/concepts/Formula.lutaml
@@ -1,20 +1,19 @@
-class Formula extends NonVerbalEntity {
+class Formula < SharedNonVerbalEntity {
   definition {
-    A dataset-level formula entity (ISO 10241-1 §6.5 non-verbal representation).
-    Authored at datasets/{ds}/formulas/{formula-id}.yaml and shared across
-    concepts. The mathematical expression is stored in a notation format.
+    A dataset-level formula entity (ISO 10241-1 §6.5 — non-verbal
+    representation). Authored at datasets/{ds}/formulas/{formula-id}.yaml
+    and shared across concepts. The mathematical expression is stored in a
+    notation format (LaTeX, MathML, AsciiMath).
   }
-
-  +expression: LocalizedStringMap [0..1] {
+  +expression: String [0..1] {
     definition {
-      The mathematical expression, localized. Different languages may use
-      different notation conventions.
+      The mathematical expression. The notation field declares how to
+      interpret it.
     }
   }
-
   +notation: String [0..1] {
     definition {
-      Expression notation: latex, mathml, asciimath.
+      Notation format of expression: e.g. "latex", "mathml", "asciimath".
     }
   }
 }

--- a/models/concepts/NonVerbRep.lutaml
+++ b/models/concepts/NonVerbRep.lutaml
@@ -1,20 +1,36 @@
 class NonVerbRep {
   definition {
-    A non-verbal representation of the term, used to help define it.
+    A non-verbal representation attached to a concept, used to help define it
+    (ISO 10241-1 §6.5). The concept-local inline form; the dataset-shared
+    form is Figure, Table, or Formula. NonVerbRep has no dataset-wide
+    identity — it lives at a positional slot inside the parent concept's
+    non_verb_rep collection.
   }
-  +image: <<BasicDocument>> Image [0..1] {
+  +type: NonVerbalType [1] {
     definition {
-      An image used to help define a term.
+      Discriminates the kind of non-verbal content: image, table, or formula.
     }
   }
-  +table: <<BasicDocument>> Table [0..1] {
+  +images: FigureImage [0..*] {
     definition {
-      A table used to help define a term.
+      Image variants (responsive, format fallbacks, dark/light, language-specific).
+      Each variant carries src, format, role, and optional dimensions. Used when
+      type is "image"; empty otherwise.
     }
   }
-  +formula: <<BasicDocument>> FormulaBlock [0..1] {
+  +caption: LocalizedStringMap [0..1] {
     definition {
-      A formula used to help define a term.
+      Localized short title for the representation, keyed by ISO 639 code.
+    }
+  }
+  +description: LocalizedStringMap [0..1] {
+    definition {
+      Localized long description, used by screen readers and long-desc links.
+    }
+  }
+  +alt: LocalizedStringMap [0..1] {
+    definition {
+      Localized alternative text — short label for screen readers (a11y).
     }
   }
   +sources: ConceptSource [0..*] {

--- a/models/concepts/NonVerbalEntity.lutaml
+++ b/models/concepts/NonVerbalEntity.lutaml
@@ -1,48 +1,29 @@
-class NonVerbalEntity {
+abstract class NonVerbalEntity {
   definition {
-    Abstract base for dataset-level non-verbal representation entities
-    (ISO 10241-1 §6.5). Figures, Tables, and Formulas inherit common
-    metadata: stable identity, localized caption/description (accessibility),
-    and provenance sources. Each is authored once at the dataset level and
-    referenced by any number of concepts.
+    Shared payload for every non-verbal representation, whether it lives
+    inline on a concept (NonVerbRep) or as a dataset-shared file
+    (Figure / Table / Formula). The four attributes here are the common
+    accessibility + provenance payload every non-verbal entity carries,
+    regardless of content type or scope.
   }
-
-  +id: String [1] {
-    definition {
-      Stable identifier, dataset-unique. Used in inline mentions
-      ({{fig:id}}, {{table:id}}, {{formula:id}}) and structural
-      references (figures: [], tables: [], formulas: []).
-    }
-  }
-
-  +identifier: String [0..1] {
-    definition {
-      Display form ("Figure 7c", "Table 2", "Equation 1").
-      Optional; consumers may auto-derive.
-    }
-  }
-
   +caption: LocalizedStringMap [0..1] {
     definition {
-      Localized title/caption, keyed by ISO 639-2 language code.
+      Localized short title — used for indexing and figure lists.
     }
   }
-
   +description: LocalizedStringMap [0..1] {
     definition {
-      Localized long description for accessibility (aria-describedby).
+      Localized long description — used by screen readers and long-desc links.
     }
   }
-
   +alt: LocalizedStringMap [0..1] {
     definition {
-      Localized short alt text for screen readers.
+      Localized alternative text — short label for screen readers (a11y).
     }
   }
-
   +sources: ConceptSource [0..*] {
     definition {
-      Bibliographic sources (provenance), parallel to concept sources.
+      Bibliographic sources for the representation.
     }
   }
 }

--- a/models/concepts/NonVerbalType.lutaml
+++ b/models/concepts/NonVerbalType.lutaml
@@ -1,0 +1,9 @@
+enum NonVerbalType {
+  definition {
+    Discriminator for the kind of non-verbal representation attached to a
+    concept. Used by NonVerbRep#type.
+  }
+  image
+  table
+  formula
+}

--- a/models/concepts/SharedNonVerbalEntity.lutaml
+++ b/models/concepts/SharedNonVerbalEntity.lutaml
@@ -1,0 +1,20 @@
+class SharedNonVerbalEntity < NonVerbalEntity {
+  definition {
+    A non-verbal entity that has stable dataset-wide identity. Figure, Table,
+    and Formula inherit from this; NonVerbRep (concept-local, positional)
+    inherits from NonVerbalEntity directly.
+  }
+  +id: String [1] {
+    definition {
+      Stable identifier used for cross-referencing. Matches the filename
+      (e.g. "fig_A.23" -> figures/fig_A.23.yaml). Authors cite this id via
+      inline {{fig:id}} mentions or structural figures[] entries.
+    }
+  }
+  +identifier: String [0..1] {
+    definition {
+      Human-readable label (e.g. "A.23") used for display and AsciiDoc
+      xref targets like <<fig_A.23>>.
+    }
+  }
+}

--- a/models/concepts/Table.lutaml
+++ b/models/concepts/Table.lutaml
@@ -1,21 +1,19 @@
-class Table extends NonVerbalEntity {
+class Table < SharedNonVerbalEntity {
   definition {
-    A dataset-level table entity (ISO 10241-1 §6.5 non-verbal representation).
-    Authored at datasets/{ds}/tables/{table-id}.yaml and shared across
-    concepts. Content is stored as structured data or markup.
+    A dataset-level table entity (ISO 10241-1 §6.5 — non-verbal
+    representation). Authored at datasets/{ds}/tables/{table-id}.yaml and
+    shared across concepts. The content is stored as structured data
+    (rows/columns) or as a markup string (HTML, Markdown, AsciiDoc).
   }
-
-  +content: LocalizedStringMap [0..1] {
+  +content: String [0..1] {
     definition {
-      Table content. For structured format: { headers: [...], rows: [...] }.
-      For markup format: the markup string keyed by language.
+      Table content as a markup string or serialized structure. The format
+      field declares how to interpret it.
     }
   }
-
   +format: String [0..1] {
     definition {
-      Content format: structured, html, markdown, asciidoc.
-      Defaults to structured if absent.
+      Markup format of content: e.g. "html", "markdown", "asciidoc".
     }
   }
 }

--- a/schemas/v3/bibliography.yaml
+++ b/schemas/v3/bibliography.yaml
@@ -1,0 +1,40 @@
+# Bibliography Schema (V3 glossarist dataset syntax)
+#
+# Dataset-level bibliography, authored at datasets/{ds}/bibliography.yaml.
+# A single-key mapping: { bibliography: [ BibliographyEntry, ... ] }.
+# The collection is an array of typed entries under one wrapper key — not a
+# keyed map and not a stray top-level array.
+
+$schema: "http://json-schema.org/draft-07/schema#"
+title: Bibliography
+description: A dataset's bibliography — a single-key mapping whose value is an array of typed bibliographic entries.
+
+type: object
+required: [bibliography]
+additionalProperties: false
+
+properties:
+  bibliography:
+    type: array
+    description: Ordered list of bibliographic references.
+    items:
+      type: object
+      required: [id, reference]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: Entry identifier, dataset-unique. Cited from concept sources and inline {{cite:...}} mentions.
+        reference:
+          type: string
+          description: Publication reference string (e.g. "ISO 704").
+        title:
+          type: string
+          description: Title of the referenced document.
+        link:
+          type: string
+          format: uri
+          description: URL to the referenced document.
+        type:
+          type: string
+          description: Document type (e.g. "standard").


### PR DESCRIPTION
## Summary

Adds the `bibliography.yaml` dataset model to the concept model, using the **V3 glossarist dataset syntax**: a single-key YAML mapping (`bibliography:`) whose value is an array of typed `BibliographyEntry` items. No stray top-level array, no keyed map — each entry carries its own `id`.

## Changes

- `models/concepts/BibliographyEntry.lutaml` — typed entry (`id, reference, title, link, type`).
- `models/concepts/BibliographyData.lutaml` — the file wrapper (`bibliography: BibliographyEntry [0..*]`).
- `schemas/v3/bibliography.yaml` — JSON Schema (validated with `jsonschema`: sample passes, negative test rejected).
- `README.adoc` — new `== Bibliography` section.

Companion PR: glossarist/glossarist-ruby#186 (implementation).