### PR TITLE
feat: canonical prefixes.ttl — SSOT for prefix bindings

### DIFF
--- a/ontologies/README.md
+++ b/ontologies/README.md
@@ -17,6 +17,7 @@ A comprehensive OWL ontology for the [Glossarist concept model](https://github.c
 
 ```
 ontologies/
+├── prefixes.ttl                  # Canonical prefix declarations (SSOT for all serializers)
 ├── glossarist.ttl                # Core OWL ontology — classes and properties
 ├── glossarist.context.jsonld     # JSON-LD @context for the namespace
 ├── README.md                     # This file
@@ -46,6 +47,8 @@ ontologies/
 ```
 
 ## Design Principles
+
+0. **Canonical prefixes** — `prefixes.ttl` is the single source of truth for prefix bindings. Every serializer (glossarist-ruby, glossarist-js, concept-browser) references this file verbatim. The canonical SKOS-XL prefix is `skosxl:` (per W3C convention); `xl:` is intentionally absent. Do not introduce alternative prefix spellings in downstream consumers.
 
 1. **SKOS alignment** — `gloss:Concept` is a `skos:Concept`. Designations use `skosxl:Label`. Instant interoperability with SKOS tooling.
 

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -14,13 +14,16 @@
 #
 # Every class and property here has a direct correspondence to a field in the
 # Glossarist YAML schema (schemas/v3/concept.yaml, localized-concept.yaml).
+#
+# Prefix bindings: see prefixes.ttl for the canonical SSOT. The declarations
+# below must stay in sync with that file.
 
 @prefix gloss:    <https://www.glossarist.org/ontologies/> .
 @prefix owl:      <http://www.w3.org/2002/07/owl#> .
 @prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
-@prefix xl:       <http://www.w3.org/2008/05/skos-xl#> .
+@prefix skosxl:    <http://www.w3.org/2008/05/skos-xl#> .
 @prefix iso-thes: <http://purl.org/iso25964/skos-thes#> .
 @prefix dcterms:  <http://purl.org/dc/terms/> .
 @prefix prov:     <http://www.w3.org/ns/prov#> .
@@ -93,11 +96,11 @@ gloss:LocalizedConcept a owl:Class ;
 # ── Designation Hierarchy (MECE) ─────────────────────────────────────────
 
 gloss:Designation a owl:Class ;
-  rdfs:subClassOf xl:Label ;
+  rdfs:subClassOf skosxl:Label ;
   rdfs:label "Designation"@en ;
   rdfs:comment """
     Abstract base for all designation types. A designation is both a
-    gloss:Designation and a skosxl:Label. The xl:literalForm carries the
+    gloss:Designation and a skosxl:Label. The skosxl:literalForm carries the
     designation text.
     Corresponds to Designation::Base in glossarist-ruby.
   """@en .

--- a/ontologies/prefixes.ttl
+++ b/ontologies/prefixes.ttl
@@ -1,0 +1,27 @@
+# Glossarist Canonical Prefix Declarations
+#
+# Single source of truth for prefix bindings used across the Glossarist
+# ecosystem. Consumed verbatim by every Turtle/JSON-LD/TBX serializer
+# (glossarist-ruby, glossarist-js, and any third-party emitter).
+#
+# Do NOT hand-edit downstream copies. Reference this file from the
+# concept-model repository.
+#
+# Canonical SKOS-XL prefix is `skosxl:` (per W3C convention and
+# glossarist-ruby's existing namespace registration). `xl:` is intentionally
+# absent — do not introduce it.
+
+@prefix gloss:     <https://www.glossarist.org/ontologies/> .
+@prefix owl:       <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosxl:    <http://www.w3.org/2008/05/skos-xl#> .
+@prefix iso-thes:  <http://purl.org/iso25964/skos-thes#> .
+@prefix dcterms:   <http://purl.org/dc/terms/> .
+@prefix prov:      <http://www.w3.org/ns/prov#> .
+@prefix vann:      <http://purl.org/vocab/vann/> .
+@prefix xsd:       <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh:        <http://www.w3.org/ns/shacl#> .
+@prefix foaf:      <http://xmlns.com/foaf/0.1/> .
+@prefix dcat:      <http://www.w3.org/ns/dcat#> .

--- a/ontologies/shapes/glossarist.shacl.ttl
+++ b/ontologies/shapes/glossarist.shacl.ttl
@@ -8,7 +8,7 @@
 @prefix gloss:  <https://www.glossarist.org/ontologies/> .
 @prefix sh:     <http://www.w3.org/ns/shacl#> .
 @prefix skos:   <http://www.w3.org/2004/02/skos/core#> .
-@prefix xl:     <http://www.w3.org/2008/05/skos-xl#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -175,9 +175,9 @@ gloss:ConceptCollectionShape a sh:NodeShape ;
 
 gloss:DesignationShape a sh:NodeShape ;
   sh:targetClass gloss:Designation ;
-  sh:class xl:Label ;
+  sh:class skosxl:Label ;
   sh:property [
-    sh:path xl:literalForm ;
+    sh:path skosxl:literalForm ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;


### PR DESCRIPTION
## Summary

Promotes `prefixes.ttl` to the main concept-model repo as the canonical single source of truth for prefix bindings. Every serializer (glossarist-ruby, glossarist-js, concept-browser) references this file verbatim instead of maintaining its own prefix map.

## Problem

The prefix for SKOS-XL was inconsistent across files:
- `glossarist.ttl` used `xl:`
- `glossarist.shacl.ttl` used `xl:`
- `glossarist.context.jsonld` used `skosxl:` (W3C convention)

Downstream consumers each maintained their own prefix map, causing drift.

## Fix

- **New file**: `ontologies/prefixes.ttl` — canonical prefix declarations
- **Aligned**: `glossarist.ttl` and `glossarist.shacl.ttl` now use `skosxl:` (6 replacements)
- **Documented**: ontologies README adds Design Principle #0 (Canonical prefixes)

The canonical SKOS-XL prefix is `skosxl:` (W3C convention). `xl:` is intentionally absent.

## Design principles
- **SSOT**: One file defines all prefixes; all consumers reference it
- **DRY**: No duplicate prefix maps in glossarist-ruby, glossarist-js, concept-browser
- **OCP**: New consumers opt in by referencing the file, no code changes needed