### PR TITLE
feat: establish release lifecycle for v3.1.0

### DIFF
--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -1,0 +1,61 @@
+name: Release Reminder
+
+# Posts a comment on PRs that touch ontology/schema files, reminding the
+# maintainer to cut a tag after merge. Does NOT auto-tag — tagging is a
+# maintainer decision (see RELEASE_PROCESS.md).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'ontologies/**'
+      - 'schemas/**'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              "### Release reminder",
+              "",
+              "This PR touches `ontologies/` or `schemas/`. After merge, a new",
+              "tag should be cut per the [semver policy](../blob/main/RELEASE_PROCESS.md#semver-policy).",
+              "",
+              "**Checklist:**",
+              "- [ ] Determine the semver bump (MAJOR / MINOR / PATCH)",
+              "- [ ] Update `RELEASE_NOTES.md` with consumer-facing impact",
+              "- [ ] Move `[Unreleased]` entries in `CHANGELOG.md` to the new version",
+              "- [ ] Cut the tag after merge: `git tag vX.Y.Z && git push origin vX.Y.Z`",
+              "",
+              "The tag push will trigger `release.yml` to create the GitHub Release.",
+              "",
+              "If this PR is doc-only or CI-only within those paths and does NOT",
+              "warrant a release, dismiss this reminder."
+            ].join("\n");
+
+            // Check if we already posted this reminder
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const alreadyPosted = comments.some(
+              (c) => c.user.login === "github-actions[bot]" && c.body.includes("Release reminder")
+            );
+
+            if (!alreadyPosted) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to the Glossarist concept-model are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+See [RELEASE_NOTES.md](RELEASE_NOTES.md) for per-release consumer impact details
+and [RELEASE_PROCESS.md](RELEASE_PROCESS.md) for the release checklist.
+
+## [Unreleased]
+
+## [v3.1.0] — 2026-07-05
+
+### Added
+- `DatasetRegister`, `Section` classes with full property set in ontology,
+  SHACL shapes, and JSON-LD context
+- `NonVerbalEntity` hierarchy: `SharedNonVerbalEntity`, `Figure`, `Table`,
+  `Formula`, `FigureImage`
+- `DesignationRelationship` class for designation-level relationships
+  (ISO 10241-1 §5.4.2)
+- `ConceptSource#id` for inline `{{cite:id}}` mentions
+- `hasScopedExample` property (MECE with concept-level `hasExample`)
+  for VIM 1993 style nested examples
+- Scoped examples (`examples`) on `DetailedDefinition` in v2/v3 YAML schemas
+- `hasChildSection` / `hasParentSection` as `owl:TransitiveProperty` for
+  cascading section membership
+- New properties: `caption`, `altText`, `description`, `expression`,
+  `latexForm`, `content`, `hasSubfigure`, `src`, `format`, `role`
+- `ontologies/prefixes.ttl` — canonical prefix declarations (SSOT)
+- New SKOS taxonomies: `ordering-method.ttl`, `concept-reference-type.ttl`
+- 52 relationship types in `related_concept_type` enum
+- `annotations` field on `LocalizedConcept`
+- New examples: `18-hierarchical-sections-{register,concept}.yaml`
+- `RELEASE_NOTES.md`, `CHANGELOG.md`, `RELEASE_PROCESS.md`
+
+### Changed
+- Canonical SKOS-XL prefix changed from `xl:` to `skosxl:` (same IRI:
+  `http://www.w3.org/2008/05/skos-xl#`). RDF semantics unchanged.
+- `DetailedDefinition` definition text updated to document shape reuse
+- `ConceptSource.lutaml` definition updated for cite mention pattern
+
+### Fixed
+- Cross-layer MECE violation: SHACL class declarations moved to ontology
+- `Figure`/`Table`/`Formula` now inherit through `SharedNonVerbalEntity`
+  (matching Lutaml model)
+- `NonVerbalRepShape` renamed to `NonVerbalRepresentationShape` targeting
+  the existing class
+- Missing properties (`expression`, `latexForm`, `content`) declared in ontology
+- All inline mention syntax standardized: `{{cite:id}}` (was `{{cite:<id>}}`)
+
+## [v3.0.0] — 2026-06-27
+
+Initial tagged release of the V3 concept model.
+
+[Unreleased]: https://github.com/glossarist/concept-model/compare/v3.1.0...HEAD
+[v3.1.0]: https://github.com/glossarist/concept-model/releases/tag/v3.1.0
+[v3.0.0]: https://github.com/glossarist/concept-model/releases/tag/v3.0.0

--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,32 @@ These models align with multiple ISO standards for terminology management:
 These models are meant to be fully compatible with the data in the IEC Electropedia.
 
 
+== Versioning and releases
+
+This repo follows semantic versioning. Consumers (glossarist-ruby,
+glossarist-js, concept-browser) vendor the ontology and schema artifacts
+and pin to tags.
+
+[cols="1,3",options="header"]
+|===
+|Bump |When
+
+|MAJOR (vN+1.0.0)
+|Removed or renamed shape, class, property, prefix binding, or enum value
+
+|MINOR (vN.N+1.0)
+|New shapes, classes, properties, enum values; backward-compatible additive
+
+|PATCH (vN.N.N+1)
+|Shape bug fixes, doc/comment-only changes, example updates
+|===
+
+A prefix spelling change (e.g. `xl:` → `skosxl:`) is MINOR if the IRI
+binding is unchanged. See xref:RELEASE_PROCESS.md[RELEASE_PROCESS.md] for
+the full release checklist and xref:CHANGELOG.md[CHANGELOG.md] for the
+release history.
+
+
 == Concept-Term interaction cycle
 
 image::concept-term-cycle.png[]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,69 @@
+# Release Notes
+
+Per-release notes for the Glossarist concept-model. Each entry summarizes
+ontology, schema, and shape changes with consumer impact.
+
+Consumers that vendor concept-model artifacts (glossarist-ruby,
+glossarist-js, concept-browser) should consult these notes when bumping
+their pinned tag.
+
+---
+
+## v3.1.0 — 2026-07-05
+
+Additive release: new classes, properties, shapes, and examples. No
+existing URI was removed or renamed. The prefix spelling change
+(`xl:` → `skosxl:`) preserves the same IRI binding.
+
+### New ontology classes
+
+- `gloss:DatasetRegister` — self-describing dataset metadata (register.yaml)
+- `gloss:Section` — structural division within a dataset (hierarchical)
+- `gloss:NonVerbalEntity` — abstract base for non-verbal representations
+- `gloss:SharedNonVerbalEntity` — dataset-wide identity (parent of Figure/Table/Formula)
+- `gloss:Figure`, `gloss:Table`, `gloss:Formula` — dataset-level NVR entities
+- `gloss:FigureImage` — image variant within a Figure
+- `gloss:DesignationRelationship` — designation-level relationship (ISO 10241-1 §5.4.2)
+
+### New SHACL shapes
+
+- `DatasetRegisterShape`, `SectionShape`
+- `FigureShape`, `TableShape`, `FormulaShape`
+- `ImageShape` (targets `foaf:Image`)
+- `NonVerbalRepresentationShape` (concept-level NVR)
+
+### New properties
+
+- Dataset register: `datasetId`, `datasetUrn`, `datasetStatus`, `hasSection`,
+  `hasDefaultOrdering`, `owner`, `sourceRepo`, `languageOrder`, etc.
+- Section: `sectionId`, `sectionName`, `hasChildSection` (transitive),
+  `hasParentSection` (transitive inverse), `sectionOrdering`
+- Non-verbal: `caption`, `altText`, `description`, `expression`, `latexForm`,
+  `content`, `hasSubfigure`, `src`, `format`, `role`
+- Concept source: `sourceId` (for `{{cite:id}}` inline mentions)
+- Scoped examples: `hasScopedExample` (MECE with concept-level `hasExample`)
+- Designation: `hasDesignationRelationship`, `designationRelationshipType`,
+  `designationRelationshipContent`, `relationshipTarget`
+
+### New SKOS taxonomies
+
+- `ontologies/taxonomies/ordering-method.ttl` — systematic, mixed, alphabetical
+- `ontologies/taxonomies/concept-reference-type.ttl` — domain, section, local, designation
+
+### Canonical prefixes
+
+- `ontologies/prefixes.ttl` — single source of truth for prefix bindings
+- `skosxl:` is the canonical SKOS-XL prefix (was `xl:` in v3.0.0)
+
+### Consumer impact
+
+| Consumer | Action needed |
+|---|---|
+| glossarist-ruby | Re-sync vendored data: `rake glossarist:sync:model[v3.1.0]` |
+| glossarist-js | Re-sync vendored data to v3.1.0 |
+| concept-browser | Update vendored shapes; prefix `xl:` → `skosxl:` in any local declarations |
+
+### Known follow-ups
+
+- Emitter-level fixes in glossarist-ruby for full SHACL conformance
+  (see glossarist-ruby PR #188 Phase 2)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,75 @@
+# Release Process
+
+This document describes how to cut a release of the Glossarist concept-model.
+
+## When to release
+
+Cut a tag whenever a PR merge touches `ontologies/` or `schemas/`.
+Skip otherwise (CI-only changes, README tweaks, example-only updates
+do not need a release).
+
+The `release-reminder.yml` workflow posts a comment on merged PRs that
+touch these paths, reminding the maintainer to cut a tag.
+
+## Semver policy
+
+| Bump | When |
+|------|------|
+| **MAJOR** (vN+1.0.0) | Removed or renamed shape, class, property, prefix binding, or enum value |
+| **MINOR** (vN.N+1.0) | New shapes, classes, properties, enum values; backward-compatible additive |
+| **PATCH** (vN.N.N+1) | Shape bug fixes, doc/comment-only changes, example updates |
+
+### Prefix and IRI semantics
+
+A prefix spelling change (e.g. `xl:` → `skosxl:`) is **MINOR** if the
+underlying IRI binding is unchanged. RDF consumers operate on IRIs,
+not prefix spellings.
+
+### SHACL shape additions
+
+Adding a new SHACL shape is **MINOR** — it validates new types but
+does not reject data that was previously valid (the shape only fires
+on instances claiming its target class).
+
+Adding a new `sh:minCount` or `sh:maxCount` constraint to an existing
+shape is **MAJOR** — it can reject previously valid data.
+
+## Release checklist
+
+1. **Verify the diff.** `git log vPREV..HEAD --oneline` — confirm all
+   changes are accounted for in `CHANGELOG.md`.
+
+2. **Update docs.**
+   - Add release entry to `RELEASE_NOTES.md` (consumer-facing impact)
+   - Move `[Unreleased]` entries to the new version in `CHANGELOG.md`
+   - Verify the semver bump matches the policy above
+
+3. **Commit.** Create a PR with the doc updates. Rebase-merge to main.
+
+4. **Tag.** Cut the tag on the merged commit:
+   ```bash
+   git tag v3.X.Y
+   git push origin v3.X.Y
+   ```
+   The tag push triggers the `release.yml` workflow, which creates the
+   GitHub Release with auto-generated notes.
+
+5. **Notify consumers.** Open issues in glossarist-ruby, glossarist-js,
+   and concept-browser to bump their vendored pin:
+   - glossarist-ruby: `rake glossarist:sync:model[v3.X.Y]`
+   - glossarist-js: update the vendored copy
+   - concept-browser: update `data/concept-model/`
+
+## Consumer contract
+
+Consumers vendor concept-model artifacts:
+- `ontologies/glossarist.ttl`
+- `ontologies/glossarist.context.jsonld`
+- `ontologies/shapes/glossarist.shacl.ttl`
+- `ontologies/prefixes.ttl`
+- `ontologies/taxonomies/*.ttl`
+
+Consumers should:
+- Pin to a tag (record it in `SOURCE.json` or equivalent)
+- Bump deliberately when ready for new shapes/classes
+- Detect drift via the `schema_version` field


### PR DESCRIPTION
Closes #66.

## Summary

Establishes the tag lifecycle policy requested in issue #66. Three consumers (glossarist-ruby, glossarist-js, concept-browser) vendor concept-model artifacts and were diverging because there was no tag past v3.0.0 (14 commits behind HEAD).

## Added

| File | Purpose |
|---|---|
| `RELEASE_NOTES.md` | v3.1.0 release notes with consumer-facing impact table |
| `CHANGELOG.md` | Rolling log (Keep a Changelog format) |
| `RELEASE_PROCESS.md` | Semver policy + release checklist |
| `.github/workflows/release-reminder.yml` | Posts reminder on PRs touching `ontologies/` or `schemas/` |
| `README.adoc` | Versioning and releases section |

## Semver: v3.1.0 (MINOR)

All 14 commits since v3.0.0 are additive. No existing URI was removed or renamed. The `xl:` → `skosxl:` prefix change preserves the same IRI binding (`http://www.w3.org/2008/05/skos-xl#`).

## What this does NOT do

- Does NOT auto-tag. Tagging remains a maintainer decision (per repo rules). The reminder workflow only posts a comment.
- Does NOT cut the v3.1.0 tag. That's the maintainer's next step after this PR merges.

## After merge

Cut the tag:
```bash
git tag v3.1.0
git push origin v3.1.0
```
The tag push triggers `release.yml` to create the GitHub Release.