### PR TITLE
fix(schemas): duplicate description key on V2 DetailedDefinition.examples

### DIFF
--- a/schemas/v2/localized-concept.yaml
+++ b/schemas/v2/localized-concept.yaml
@@ -455,13 +455,13 @@ $defs:
         type: array
         items:
           $ref: "#/$defs/concept_source"
+        description: Bibliographic references for this particular definition of the concept.
       examples:
         type: array
         items:
           $ref: "#/$defs/detailed_definition"
         description: >-
           Examples scoped to this entry (VIM 1993 style nesting).
-        description: Bibliographic references for this particular definition of the concept.
 
   # Data Types
   iso639_three_char_code:


### PR DESCRIPTION
The V2 localized-concept.yaml schema has a duplicate description key on detailed_definition.examples. The new scoped-examples description (added in v3.1.0 for the VIM 1993 nesting feature) was committed on top of the existing sources description, which had drifted onto the wrong field.

Strict YAML parsers (e.g. the yaml package's default mode used by glossarist.org's bundle-schemas script) reject this as DUPLICATE_KEY, breaking the website's build.

This PR moves the bibliographic description to its intended home on sources (matching the V3 schema shape) and keeps the scoped-examples description on examples.

Discovered by glossarist.org CI while syncing to v3.1.0 (PR #59).