### PR TITLE
fix(model): sourced_from citations must include locality

### DIFF
--- a/TODO.source/01-glossarist-ruby-sourced-from.md
+++ b/TODO.source/01-glossarist-ruby-sourced-from.md
@@ -1,0 +1,70 @@
+# 01 — glossarist-ruby: Add `sourced_from` to ConceptSource
+
+## Context
+
+The concept-model now defines `sourced_from` on `ConceptSource` as an array of
+`Citation` objects, representing the upstream documents a lineage source was
+itself sourced from. The concept-model schemas, ontology, SHACL shapes, and
+JSON-LD context have been updated.
+
+## Changes
+
+### 1. Base class: `lib/glossarist/concept_source.rb`
+
+Add `sourced_from` attribute (array of `Citation`) and its key_value mapping:
+
+```ruby
+attribute :sourced_from, Citation, collection: true
+
+key_value do
+  map :sourced_from, to: :sourced_from
+  # ... existing maps
+end
+```
+
+### 2. V2 override: `lib/glossarist/v2/concept_source.rb`
+
+Override `sourced_from` to use `V2::Citation`:
+
+```ruby
+attribute :sourced_from, V2::Citation, collection: true
+
+key_value do
+  map :sourced_from, to: :sourced_from
+  # ... existing maps
+end
+```
+
+### 3. V3 override: `lib/glossarist/v3/concept_source.rb`
+
+Override `sourced_from` to use `V3::Citation`:
+
+```ruby
+attribute :sourced_from, V3::Citation, collection: true
+
+key_value do
+  map :sourced_from, to: :sourced_from
+  # ... existing maps
+end
+```
+
+### 4. RDF emitter: `lib/glossarist/rdf/gloss_concept_source.rb`
+
+Emit `gloss:sourcedFrom` triples for each `sourced_from` Citation, pointing to
+the Citation resource (same pattern as `gloss:sourceOrigin`).
+
+### 5. Tests: `spec/unit/concept_source_spec.rb`
+
+Add tests for:
+- `sourced_from` defaults to empty collection
+- `sourced_from` round-trips through YAML with one Citation
+- `sourced_from` round-trips through YAML with multiple Citations
+- `sourced_from` works with V3 structured Citation::Ref
+
+## Validation
+
+```sh
+cd /Users/mulgogi/src/glossarist/glossarist-ruby
+bundle exec rspec spec/unit/concept_source_spec.rb
+bundle exec rubocop lib/glossarist/concept_source.rb lib/glossarist/v2/concept_source.rb lib/glossarist/v3/concept_source.rb
+```

--- a/TODO.source/02-glossarist-js-sourced-from.md
+++ b/TODO.source/02-glossarist-js-sourced-from.md
@@ -1,0 +1,75 @@
+# 02 — glossarist-js: Add `sourced_from` to ConceptSource
+
+## Context
+
+The concept-model now defines `sourced_from` on `ConceptSource` as an array of
+`Citation` objects. The JS implementation needs to parse, store, and serialize
+this field.
+
+## Changes
+
+### 1. Model: `src/models/concept-source.js`
+
+Add `sourced_from` to the constructor (eager array pattern, like
+`Designation.sources`):
+
+```js
+this.sourced_from = (data.sourced_from ?? []).map(
+  c => c instanceof Citation ? c : new Citation(c)
+);
+```
+
+Add to `toJSON()`:
+
+```js
+if (this.sourced_from.length > 0) obj.sourced_from = this.sourced_from.map(c => c.toJSON());
+```
+
+### 2. TypeScript types: `src/models/index.d.ts`
+
+Add `sourced_from` to the `ConceptSource` class declaration:
+
+```ts
+export class ConceptSource extends GlossaristModel {
+  readonly status: string | null;
+  readonly type: string | null;
+  readonly origin: Citation | null;
+  readonly modification: string | null;
+  readonly sourced_from: Citation[];
+}
+```
+
+### 3. RDF emitter: `src/rdf/gloss-source.js`
+
+Emit `gloss:sourcedFrom` quads for each `sourced_from` Citation, using the same
+pattern as `sourceOrigin` (lines 29-51). Each `sourced_from` Citation is emitted
+as a blank node with `gloss:hasCitationRef`, `gloss:hasCitationLocality`, etc.
+
+### 4. Predicates: `src/rdf/predicates.js`
+
+Add the `sourcedFrom` predicate entry (already exists in the JSON-LD context as
+`gloss:sourcedFrom`):
+
+```js
+sourcedFrom: 'https://www.glossarist.org/ontologies/sourcedFrom',
+```
+
+### 5. Tests: `test/models/concept-source.test.js`
+
+Add tests for:
+- `sourced_from` defaults to empty array
+- `sourced_from` wraps plain objects as Citation instances
+- `sourced_from` round-trips through toJSON/fromJSON
+- `sourced_from` with multiple citations
+
+### 6. RDF tests: `test/rdf/gloss-source.test.js`
+
+Add test for `sourced_from` RDF emission.
+
+## Validation
+
+```sh
+cd /Users/mulgogi/src/glossarist/glossarist-js
+npm test
+npm run lint
+```

--- a/TODO.source/03-concept-browser-sourced-from.md
+++ b/TODO.source/03-concept-browser-sourced-from.md
@@ -1,0 +1,78 @@
+# 03 — concept-browser: Display `sourced_from` on sources
+
+## Context
+
+The concept-model now defines `sourced_from` on `ConceptSource` as an array of
+`Citation` objects. The concept-browser needs to:
+1. Pass `sourced_from` through the data bridge (JSON-LD → native format)
+2. Render `sourced_from` citations alongside each source's `origin`
+
+## Changes
+
+### 1. TypeScript augmentation: `src/adapters/non-verbal/glossarist-augment.d.ts`
+
+Add `sourced_from` to the `ConceptSource` class via module augmentation:
+
+```ts
+declare module 'glossarist' {
+  interface ConceptSource {
+    sourced_from?: Citation[];
+  }
+}
+```
+
+### 2. JSON-LD bridge: `src/adapters/model-bridge.ts`
+
+- `JsonLdSource` interface (line ~100): add `'gl:sourced_from'?: JsonLdOrigin[]`
+- `mapSourceFromJsonLd()` (line ~411): map `'gl:sourced_from'` to
+  `sourced_from` in the native format, converting each entry through the same
+  origin-mapping logic used for `origin`.
+
+### 3. Non-verbal bridge: `src/adapters/non-verbal/`
+
+- `types.ts`: add `sourced_from?: NonVerbalSourceOrigin[]` to `NonVerbalSource`
+- `source-bridge.ts`: parse `sourced_from` in `sourceFromJsonLd()`
+
+### 4. Rendering — add `sourced_from` display after origin CitationDisplay
+
+Each source rendering location gets a "sourced from" subsection listing the
+upstream citations via the existing `CitationDisplay` component.
+
+**Files to update:**
+
+- `src/components/ConceptDetail.vue` — per-language sources (line ~439-452) and
+  concept-level sources (line ~604-619)
+- `src/components/DesignationList.vue` — designation sources (line ~59-64)
+- `src/components/NonVerbalRepDisplay.vue` — non-verbal rep sources (line ~61-66)
+- `src/components/non-verbal/NonVerbalSources.vue` — shared non-verbal sources
+- `src/components/LanguageDetail.vue` — standalone language page sources (line ~167-181)
+
+**Render pattern:**
+
+```vue
+<div v-if="src.sourced_from?.length" class="text-xs text-ink-400 mt-1">
+  <span class="text-ink-300">{{ t('concept.sourcedFrom') }}:</span>
+  <div v-for="(sf, sfi) in src.sourced_from" :key="'sf'+sfi" class="ml-2">
+    <CitationDisplay v-if="sf" :citation="sf" :register-id="registerId" />
+  </div>
+</div>
+```
+
+### 5. i18n strings
+
+Add `concept.sourcedFrom` translation key ("Sourced from" in English) to the
+locale files.
+
+### 6. Test fixtures
+
+- `src/__tests__/__fixtures__/concepts.ts`: add `sourced_from` to the
+  `withSources()` fixture
+- Any RDF conformance test fixtures that include sources
+
+## Validation
+
+```sh
+cd /Users/mulgogi/src/glossarist/concept-browser
+npm run build
+npm test
+```

--- a/models/concepts/ConceptSource.lutaml
+++ b/models/concepts/ConceptSource.lutaml
@@ -30,14 +30,33 @@ class ConceptSource {
       The type of the managed term in the present context.
     }
   }
-  +origin: <<Bibliography>> Citation {
+  +origin: <<Bibliography>> Citation [1..1] {
     definition {
-      The bibliographic citation for the managed term.
+      The bibliographic citation for the managed term, including
+      the source document reference (ref) and the locality within
+      that document (clause, section, page, etc.) where the term
+      is defined.
     }
   }
   +modification: <<BasicDocument>> ParagraphBlock [0..1] {
     definition {
       A description of the modification to the cited definition of the term, if any, as it is to be applied in the present context.
+    }
+  }
+  +sourced_from: <<Bibliography>> Citation [0..*] {
+    definition {
+      Citations to the upstream documents that `origin` was itself
+      sourced from, forming a provenance chain. Each entry is a
+      full Citation including both `ref` (the document identifier)
+      and `locality` (the clause/section within that document where
+      the term appears) — a sourced_from entry without a locality
+      is incomplete because the reader cannot locate the definition
+      in the upstream document.
+
+      Only valid on sources of type `lineage`; authoritative sources
+      are terminal (no sourced_from). When present, `status` and
+      `modification` describe how `origin` relates to these upstream
+      sources.
     }
   }
 }

--- a/ontologies/glossarist.context.jsonld
+++ b/ontologies/glossarist.context.jsonld
@@ -125,6 +125,7 @@
     "sourceId":            { "@id": "gloss:sourceId",      "@type": "xsd:string" },
     "sourceOrigin":        { "@id": "gloss:sourceOrigin",  "@type": "@id" },
     "modification":        { "@id": "gloss:modification",  "@type": "xsd:string" },
+    "sourcedFrom":         { "@id": "gloss:sourcedFrom",   "@type": "@id" },
 
     "hasCitationRef":      { "@id": "gloss:hasCitationRef", "@type": "@id" },
     "hasCitationLocality": { "@id": "gloss:hasCitationLocality", "@type": "@id" },

--- a/ontologies/glossarist.ttl
+++ b/ontologies/glossarist.ttl
@@ -720,6 +720,17 @@ gloss:modification a owl:DatatypeProperty ;
   rdfs:label "modification"@en ;
   rdfs:comment "How the concept was modified from the source."@en .
 
+gloss:sourcedFrom a owl:ObjectProperty ;
+  rdfs:domain gloss:ConceptSource ;
+  rdfs:range gloss:Citation ;
+  rdfs:label "sourced from"@en ;
+  rdfs:comment """
+    Citations to the documents that this source was itself sourced
+    from. Only valid on lineage sources; authoritative sources are
+    terminal. When present, status and modification describe how
+    origin relates to these upstream sources.
+  """@en .
+
 # ── Citation resolution ────────────────────────────────────────────────────
 #
 # An inline `{{cite:id}}` mention in a concept's text

--- a/ontologies/shapes/glossarist.shacl.ttl
+++ b/ontologies/shapes/glossarist.shacl.ttl
@@ -391,6 +391,24 @@ gloss:ConceptSourceShape a sh:NodeShape ;
     sh:path gloss:modification ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path gloss:sourcedFrom ;
+    sh:class gloss:Citation ;
+  ] ;
+  sh:sparql [
+    sh:message "sourced_from is only allowed on sources of type lineage"@en ;
+    sh:select """
+      PREFIX gloss: <https://www.glossarist.org/ontologies/>
+      PREFIX srctype: <https://www.glossarist.org/ontologies/srctype/>
+      SELECT $this
+      WHERE {
+        $this gloss:sourcedFrom ?target .
+        FILTER NOT EXISTS {
+          $this gloss:sourceType srctype:lineage .
+        }
+      }
+    """ ;
   ] .
 
 gloss:ConceptDateShape a sh:NodeShape ;

--- a/schemas/v3/concept.yaml
+++ b/schemas/v3/concept.yaml
@@ -336,6 +336,21 @@ $defs:
       modification:
         type: string
         description: How the concept was modified from the source.
+      sourced_from:
+        type: array
+        description: |
+          Citations to the documents that this source was itself sourced
+          from. Only valid on sources of type `lineage`; authoritative
+          sources are terminal. When present, `status` and `modification`
+          describe how `origin` relates to these upstream sources.
+          Each citation MUST include a `locality` so the reader can
+          locate the definition in the upstream document.
+        items:
+          allOf:
+            - $ref: "#/$defs/citation"
+          required:
+            - ref
+            - locality
 
   # Concept Source Type enum
   concept_source_type:

--- a/schemas/v3/examples/07-sources.yaml
+++ b/schemas/v3/examples/07-sources.yaml
@@ -4,6 +4,12 @@
 # definition/note/example level, and designation level.
 # Each source has a type (authoritative/lineage), status, and origin citation.
 # V3 format: origin.ref is always a hash { source, id, version? }.
+#
+# Provenance chains: a lineage source may carry `sourced_from` — an
+# array of Citations pointing to upstream documents it was sourced from.
+# The authoritative source is terminal (no sourced_from). When
+# sourced_from is present, `status` and `modification` describe how
+# `origin` relates to the upstream sources.
 
 ---
 id: "151-01-01"
@@ -12,23 +18,50 @@ data:
   localized_concepts:
     eng: 44444444-aaaa-bbbb-cccc-dddddddddddd
 
-  # Managed concept level sources
+  # Managed concept level sources — provenance chain.
+  # The term originates in OIML V 1:2000 (authoritative, terminal),
+  # was reproduced in OIML B 3:2003 (lineage), and again in
+  # OIML G 18:2010 (lineage, the document being authored).
   sources:
-    # Authoritative source — the concept is directly from this standard
     - type: authoritative
       origin:
         ref:
-          source: "ISO"
-          id: "10241-1"
-          version: "2011"
+          source: "OIML"
+          id: "V 1"
+          version: "2000"
         locality:
           type: clause
           reference_from: "3.1"
-    # Lineage source — historical/provenance reference
     - type: lineage
+      status: identical
       origin:
         ref:
-          source: "ISO/IEC Guide 2:2004"
+          source: "OIML"
+          id: "B 3"
+          version: "2003"
+      sourced_from:
+        - ref:
+            source: "OIML"
+            id: "V 1"
+            version: "2000"
+          locality:
+            type: clause
+            reference_from: "3.1"
+    - type: lineage
+      status: identical
+      origin:
+        ref:
+          source: "OIML"
+          id: "G 18"
+          version: "2010"
+      sourced_from:
+        - ref:
+            source: "OIML"
+            id: "B 3"
+            version: "2003"
+          locality:
+            type: clause
+            reference_from: "2.7"
 
   related:
     - type: supersedes

--- a/schemas/v3/figure.yaml
+++ b/schemas/v3/figure.yaml
@@ -90,3 +90,10 @@ $defs:
         enum: [authoritative, lineage]
       origin:
         type: object
+      sourced_from:
+        type: array
+        description: |
+          Citations to documents that this source was sourced from.
+          Only valid on lineage sources; authoritative sources are terminal.
+        items:
+          type: object

--- a/schemas/v3/localized-concept.yaml
+++ b/schemas/v3/localized-concept.yaml
@@ -578,6 +578,15 @@ $defs:
       modification:
         type: string
         description: Modification of the concept source
+      sourced_from:
+        type: array
+        description: |
+          Citations to the documents that this source was itself sourced
+          from. Only valid on sources of type `lineage`; authoritative
+          sources are terminal. When present, `status` and `modification`
+          describe how `origin` relates to these upstream sources.
+        items:
+          $ref: "#/$defs/citation"
 
   # Reference (typed classification — domains, typed references)
   reference:


### PR DESCRIPTION
## Summary

- Add `sourced_from` attribute to ConceptSource model (.lutaml) with documentation requiring locality
- JSON schema: change `sourced_from.items` from bare `: citation` to `allOf` with `required: [ref, locality]`
- Update example 07-sources.yaml to show locality in every `sourced_from` entry

A sourced_from without locality is incomplete — the reader knows the upstream document but not which clause to look at.