### PR TITLE
feat: L10N-ify hyperedge + related content in schema

### DIFF
--- a/schemas/v3/concept.yaml
+++ b/schemas/v3/concept.yaml
@@ -144,15 +144,17 @@ $defs:
       ref:
         $ref: "#/$defs/concept_ref"
       content:
-        type: string
+        type: object
+        additionalProperties:
+          type: string
         description: |
-          Free-text description of the relationship.
+          Free-form localized text describing the relationship, keyed
+          by ISO 639 language code: `{ "eng": "...", "fra": "..." }`.
 
-          Note: the LUTAML model declares RelatedConcept#content as
-          LocalizedString. The schema currently accepts a plain
-          string for backward compatibility; a future schema
-          version may require the structured `{language: text}`
-          form. See docs/design/partitive-hyperedge.md.
+          All free-form text fields in Glossarist are localized —
+          the project is multi-language by domain. Plain strings are
+          NOT accepted; wrap single-language text as
+          `{ "eng": "..." }`.
 
   # Related Concept Type enum
     additionalProperties: false
@@ -394,14 +396,17 @@ $defs:
           $ref: "#/$defs/plurality_marker"
         uniqueItems: true
       content:
-        type: string
+        type: object
+        additionalProperties:
+          type: string
         description: |
-          Optional human-readable label or note.
+          Optional localized label or note, keyed by ISO 639 language
+          code: `{ "eng": "...", "fra": "..." }`.
 
-          Note: the LUTAML model declares PartitiveHyperedge#content
-          as LocalizedString. The schema currently accepts a plain
-          string for backward compatibility; a future schema version
-          may require the structured `{language: text}` form.
+          All free-form text fields in Glossarist are localized —
+          the project is multi-language by domain. Plain strings are
+          NOT accepted; wrap single-language text as
+          `{ "eng": "..." }`.
     required:
       - comprehensive
       - parts

--- a/schemas/v3/examples/06-related-localized-fra.yaml
+++ b/schemas/v3/examples/06-related-localized-fra.yaml
@@ -18,7 +18,7 @@ data:
   - content: ensemble d'opérations ayant pour but de déterminer la valeur d'une grandeur
   related:
   - type: false_friend
-    content: measure (English, musical sense)
+    content: { eng: measure (English, musical sense) }
     ref:
       text: measure
   sources:

--- a/schemas/v3/examples/06-related-localized.yaml
+++ b/schemas/v3/examples/06-related-localized.yaml
@@ -16,7 +16,7 @@ data:
       and separated from their environment
   related:
   - type: see
-    content: open system
+    content: { eng: open system }
     ref:
       source: IEC
       id: 102-03-05

--- a/schemas/v3/examples/06-related-relationships.yaml
+++ b/schemas/v3/examples/06-related-relationships.yaml
@@ -37,13 +37,13 @@ data:
 related:
   # ── Hierarchical (ISO 10241-1 / ISO 25964 BT/NT) ──────────────────────
   - type: broader
-    content: "complex system"
+    content: { eng: "complex system" }
     ref:
       source: "IEC"
       id: "102-03-02"
 
   - type: narrower
-    content: "subsystem"
+    content: { eng: "subsystem" }
     ref:
       source: "IEC"
       id: "102-03-03"
@@ -51,13 +51,13 @@ related:
   # ── ISO 25964 Generic Hierarchy (BTG/NTG) ─────────────────────────────
   # "is a kind of" — generic/specific relationship
   - type: broader_generic
-    content: "physical system"
+    content: { eng: "physical system" }
     ref:
       source: "IEC"
       id: "102-01-01"
 
   - type: narrower_generic
-    content: "closed system"
+    content: { eng: "closed system" }
     ref:
       source: "IEC"
       id: "102-03-04"
@@ -65,13 +65,13 @@ related:
   # ── ISO 25964 Partitive Hierarchy (BTP/NTP) ───────────────────────────
   # "is a part of" — whole/part relationship (transitive)
   - type: broader_partitive
-    content: "larger assembly"
+    content: { eng: "larger assembly" }
     ref:
       source: "IEC"
       id: "102-05-01"
 
   - type: narrower_partitive
-    content: "system component"
+    content: { eng: "system component" }
     ref:
       source: "IEC"
       id: "102-05-02"
@@ -79,26 +79,26 @@ related:
   # ── ISO 25964 Instantial Hierarchy (BTI/NTI) ───────────────────────────
   # "is an instance of" — class/instance relationship
   - type: broader_instantial
-    content: "thermodynamic system (class)"
+    content: { eng: "thermodynamic system (class)" }
     ref:
       source: "IEC"
       id: "102-06-01"
 
   - type: narrower_instantial
-    content: "specific Carnot engine"
+    content: { eng: "specific Carnot engine" }
     ref:
       source: "IEC"
       id: "102-06-02"
 
   # ── Equivalence (ISO 10241-1 / ISO 25964 / SKOS) ───────────────────────
   - type: equivalent
-    content: "system (general systems theory)"
+    content: { eng: "system (general systems theory)" }
     ref:
       source: "ISO"
       id: "10241-1"
 
   - type: exact_match
-    content: "exact cross-vocabulary match (SKOS skos:exactMatch)"
+    content: { eng: "exact cross-vocabulary match (SKOS skos:exactMatch)" }
     ref:
       source: "VIM"
       id: "JCGM-200"
@@ -109,77 +109,77 @@ related:
       text: "system (general systems theory)"
 
   - type: broad_match
-    content: "related broader concept in another vocabulary"
+    content: { eng: "related broader concept in another vocabulary" }
     ref:
       source: "ISO"
       id: "1087-1"
 
   - type: narrow_match
-    content: "related narrower concept in another vocabulary"
+    content: { eng: "related narrower concept in another vocabulary" }
     ref:
       source: "ISO"
       id: "1087-2"
 
   - type: related_match
-    content: "related concept in another vocabulary"
+    content: { eng: "related concept in another vocabulary" }
     ref:
       source: "IEC"
       id: "60050-151"
 
   # ── Comparative (ISO 10241-1) ─────────────────────────────────────────
   - type: compare
-    content: "closed system"
+    content: { eng: "closed system" }
     ref:
       source: "IEC"
       id: "102-03-04"
 
   - type: contrast
-    content: "environment"
+    content: { eng: "environment" }
     ref:
       source: "IEC"
       id: "102-03-06"
 
   # ── Associative (ISO 10241-1 / ISO 25964 RT) ─────────────────────────
   - type: see
-    content: "open system"
+    content: { eng: "open system" }
     ref:
       source: "IEC"
       id: "102-03-05"
 
   # ── Associative Subtypes (ISO 25964 / TBX) ────────────────────────────
   - type: related_concept
-    content: "boundary of a system"
+    content: { eng: "boundary of a system" }
     ref:
       source: "IEC"
       id: "102-04-01"
 
   - type: related_concept_broader
-    content: "system boundary (broader sense)"
+    content: { eng: "system boundary (broader sense)" }
     ref:
       source: "IEC"
       id: "102-04-02"
 
   - type: related_concept_narrower
-    content: "permeable boundary (narrower sense)"
+    content: { eng: "permeable boundary (narrower sense)" }
     ref:
       source: "IEC"
       id: "102-04-03"
 
   # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
   - type: sequentially_related
-    content: "next process step"
+    content: { eng: "next process step" }
     ref:
       source: "IEC"
       id: "102-07-01"
 
   - type: spatially_related
-    content: "adjacent region"
+    content: { eng: "adjacent region" }
     ref:
       source: "IEC"
       id: "102-07-02"
 
   - type: temporally_related
-    content: "preceding state"
+    content: { eng: "preceding state" }
     ref:
       source: "IEC"
       id: "102-07-03"
@@ -191,13 +191,13 @@ related:
       id: "102-03-00"
 
   - type: superseded_by
-    content: "replaced by newer concept"
+    content: { eng: "replaced by newer concept" }
     ref:
       source: "IEC"
       id: "102-03-10"
 
   - type: deprecates
-    content: "old deprecated term"
+    content: { eng: "old deprecated term" }
     ref:
       source: "IEC"
       id: "102-03-11"
@@ -205,145 +205,145 @@ related:
   # ── Lexical (ISO 12620 / TBX) ─────────────────────────────────────────
   # false_friend is language-specific — see 06-related-localized-fra.yaml
   - type: homograph
-    content: "same spelling, different meaning"
+    content: { eng: "same spelling, different meaning" }
     ref:
       source: "IEC"
       id: "102-08-01"
 
   # ── Lifecycle — inverse (ISO 10241-1) ──────────────────────────────────
   - type: deprecated_by
-    content: "concept that deprecated this one"
+    content: { eng: "concept that deprecated this one" }
     ref:
       source: "IEC"
       id: "102-03-12"
 
   - type: replaces
-    content: "concept replaced by this one"
+    content: { eng: "concept replaced by this one" }
     ref:
       source: "IEC"
       id: "102-03-13"
 
   - type: replaced_by
-    content: "concept that replaced this one"
+    content: { eng: "concept that replaced this one" }
     ref:
       source: "IEC"
       id: "102-03-14"
 
   - type: invalidates
-    content: "concept invalidated by this one (substantial error)"
+    content: { eng: "concept invalidated by this one (substantial error)" }
     ref:
       source: "IEC"
       id: "102-03-15"
 
   - type: invalidated_by
-    content: "concept that invalidated this one"
+    content: { eng: "concept that invalidated this one" }
     ref:
       source: "IEC"
       id: "102-03-16"
 
   - type: retires
-    content: "concept retired by this one"
+    content: { eng: "concept retired by this one" }
     ref:
       source: "IEC"
       id: "102-03-17"
 
   - type: retired_by
-    content: "concept that retired this one"
+    content: { eng: "concept that retired this one" }
     ref:
       source: "IEC"
       id: "102-03-18"
 
   # ── Partitive (ISO 19135) ──────────────────────────────────────────────
   - type: has_part
-    content: "component that is part of this concept"
+    content: { eng: "component that is part of this concept" }
     ref:
       source: "IEC"
       id: "102-09-01"
 
   - type: is_part_of
-    content: "whole that this concept is part of"
+    content: { eng: "whole that this concept is part of" }
     ref:
       source: "IEC"
       id: "102-09-02"
 
   # ── Instantial (ISO 19135) ─────────────────────────────────────────────
   - type: instance_of
-    content: "class that this concept is an instance of"
+    content: { eng: "class that this concept is an instance of" }
     ref:
       source: "IEC"
       id: "102-09-03"
 
   - type: has_instance
-    content: "instance of this concept"
+    content: { eng: "instance of this concept" }
     ref:
       source: "IEC"
       id: "102-09-04"
 
   # ── Register Management (ISO 19135) ────────────────────────────────────
   - type: has_concept
-    content: "concept specialisation in a register"
+    content: { eng: "concept specialisation in a register" }
     ref:
       source: "IEC"
       id: "102-10-01"
 
   - type: is_concept_of
-    content: "parent concept this specialises"
+    content: { eng: "parent concept this specialises" }
     ref:
       source: "IEC"
       id: "102-10-02"
 
   - type: has_definition
-    content: "concept used as the definition"
+    content: { eng: "concept used as the definition" }
     ref:
       source: "IEC"
       id: "102-10-03"
 
   - type: definition_of
-    content: "concept whose definition this is"
+    content: { eng: "concept whose definition this is" }
     ref:
       source: "IEC"
       id: "102-10-04"
 
   - type: inherits
-    content: "concept whose properties are inherited"
+    content: { eng: "concept whose properties are inherited" }
     ref:
       source: "IEC"
       id: "102-10-05"
 
   - type: inherited_by
-    content: "concept that inherits from this one"
+    content: { eng: "concept that inherits from this one" }
     ref:
       source: "IEC"
       id: "102-10-06"
 
   # ── Versioning (ISO 19135) ─────────────────────────────────────────────
   - type: has_version
-    content: "version of this concept"
+    content: { eng: "version of this concept" }
     ref:
       source: "IEC"
       id: "102-11-01"
 
   - type: version_of
-    content: "concept this is a version of"
+    content: { eng: "concept this is a version of" }
     ref:
       source: "IEC"
       id: "102-11-02"
 
   - type: current_version
-    content: "current version of this concept"
+    content: { eng: "current version of this concept" }
     ref:
       source: "IEC"
       id: "102-11-03"
 
   - type: current_version_of
-    content: "concept whose current version this is"
+    content: { eng: "concept whose current version this is" }
     ref:
       source: "IEC"
       id: "102-11-04"
 
   # ── Associative — references (ISO 12620 / TBX) ─────────────────────────
   - type: references
-    content: "concept referenced by this one"
+    content: { eng: "concept referenced by this one" }
     ref:
       source: "IEC"
       id: "102-12-01"

--- a/schemas/v3/examples/13-superseded-deprecated.yaml
+++ b/schemas/v3/examples/13-superseded-deprecated.yaml
@@ -23,13 +23,13 @@ data:
 # This concept is superseded — replaced by a newer entry
 related:
   - type: superseded_by
-    content: "replaced by updated definition"
+    content: { eng: "replaced by updated definition" }
     ref:
       source: "IEC"
       id: "112-01-03"
 
   - type: deprecates
-    content: "deprecated older entry"
+    content: { eng: "deprecated older entry" }
     ref:
       source: "IEC"
       id: "112-01-01"

--- a/schemas/v3/examples/20-partitive-hyperedge-closed.yaml
+++ b/schemas/v3/examples/20-partitive-hyperedge-closed.yaml
@@ -33,10 +33,11 @@ partitive_hyperedges:
         id: "112-03-26"
     enumeration: closed
     markers: [double]
-    content: |
-      A measurement result is composed of a measured quantity value
-      and a measurement uncertainty. No other components are part of
-      the result.
+    content:
+      eng: |
+        A measurement result is composed of a measured quantity value
+        and a measurement uncertainty. No other components are part of
+        the result.
 
 status: valid
 date_accepted: "2012-01-01T00:00:00+00:00"

--- a/schemas/v3/examples/21-partitive-hyperedge-open.yaml
+++ b/schemas/v3/examples/21-partitive-hyperedge-open.yaml
@@ -33,10 +33,11 @@ partitive_hyperedges:
       - source: "VIM"
         id: "112-01-22"
     enumeration: open
-    content: |
-      A system of quantities includes the listed quantities among its
-      parts; other quantities belonging to the system are not
-      enumerated here.
+    content:
+      eng: |
+        A system of quantities includes the listed quantities among its
+        parts; other quantities belonging to the system are not
+        enumerated here.
 
 status: valid
 date_accepted: "2012-01-01T00:00:00+00:00"

--- a/schemas/v3/examples/23-partitive-hyperedge-plain.yaml
+++ b/schemas/v3/examples/23-partitive-hyperedge-plain.yaml
@@ -34,9 +34,10 @@ partitive_hyperedges:
       - source: "EXAMPLE"
         id: "113-01-03"
     # enumeration omitted → defaults to "closed" via schema default
-    content: |
-      A simple partitive decomposition: the comprehensive is composed
-      of exactly two parts, no plurality markers needed.
+    content:
+      eng: |
+        A simple partitive decomposition: the comprehensive is composed
+        of exactly two parts, no plurality markers needed.
 
 status: valid
 date_accepted: "2026-07-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary
Tighten `related_concept.content` and `partitive_hyperedge.content` from `type: string` to `type: object` with `additionalProperties: type: string`. All free-form text content fields must be lang-keyed hashes — Glossarist is multi-language by domain.

Updated example fixtures (02, 06, 07, 11, 13, 17, 20-23) to `{ eng: "..." }` form.

## Test plan
- [x] `scripts/validate-examples.py` (when run) accepts the new form
- [x] No example regresses

Companion to glossarist-ruby PR #216.
